### PR TITLE
부산대 BE 정윤성 Step0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # spring-gift-order
+> 기본 코드 준비
+## 기능 요구 사항
+* spring gift enhancement에서 코드 가져오기
+* 저번 Step3 에서 받은 리뷰 반영
+  * Option Response Dto의 어노테이션 의존성 통일
+  * application.yml 중복 수정
+  * Status 다양화

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,19 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'org.mindrot:jbcrypt:0.4'
+
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/gift/config/LoginMember.java
+++ b/src/main/java/gift/config/LoginMember.java
@@ -1,0 +1,11 @@
+package gift.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+}

--- a/src/main/java/gift/config/LoginMemberArgumentResolver.java
+++ b/src/main/java/gift/config/LoginMemberArgumentResolver.java
@@ -1,0 +1,43 @@
+package gift.config;
+
+import gift.service.MemberService;
+import gift.security.JwtTokenProvider;
+import org.apache.tomcat.websocket.AuthenticationException;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String AUTHORIZATION_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
+
+    public LoginMemberArgumentResolver(JwtTokenProvider jwtTokenProvider, MemberService memberService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.memberService = memberService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+         String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+
+         if (authorizationHeader == null || !authorizationHeader.startsWith(AUTHORIZATION_PREFIX)) {
+             throw new AuthenticationException("Invalid Authorization header");
+         }
+
+         String token = authorizationHeader.substring(AUTHORIZATION_PREFIX.length());
+        long memberId = jwtTokenProvider.parseJwtToken(token).getId();
+
+        return memberService.getMember(memberId);
+    }
+}

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -1,0 +1,26 @@
+package gift.config;
+
+import gift.service.MemberService;
+import gift.security.JwtTokenProvider;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
+
+    public WebConfig(JwtTokenProvider jwtTokenProvider, MemberService memberService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.memberService = memberService;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginMemberArgumentResolver(jwtTokenProvider, memberService));
+    }
+}

--- a/src/main/java/gift/controller/AdminController.java
+++ b/src/main/java/gift/controller/AdminController.java
@@ -1,0 +1,34 @@
+package gift.controller;
+
+import gift.service.OptionService;
+import gift.service.ProductService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class AdminController {
+
+    private final ProductService productService;
+    private final OptionService optionService;
+
+    public AdminController(ProductService productService, OptionService optionService) {
+        this.productService = productService;
+        this.optionService = optionService;
+    }
+
+    @GetMapping("/admin/products")
+    public String adminProducts(Model model) {
+        model.addAttribute("products", productService.findAllProducts());
+        return "products";
+    }
+
+    @GetMapping("/admin/products/{productId}/options")
+    public String adminOptions(@PathVariable long productId, Model model) {
+        model.addAttribute("product", productService.findProductById(productId));
+        model.addAttribute("options", optionService.getProductOptions(productId, Pageable.unpaged()));
+        return "product-options";
+    }
+}

--- a/src/main/java/gift/controller/MemberController.java
+++ b/src/main/java/gift/controller/MemberController.java
@@ -1,0 +1,38 @@
+package gift.controller;
+
+import gift.dto.AuthResponseDto;
+import gift.dto.MemberRequestDto;
+import gift.service.AuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/members")
+@RestController
+public class MemberController {
+
+    private final AuthService authService;
+
+    public MemberController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponseDto> registerMember(
+            @Validated @RequestBody MemberRequestDto memberRequestDto
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                authService.register(memberRequestDto)
+        );
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponseDto> login(
+            @Validated @RequestBody MemberRequestDto memberRequestDto
+    ) {
+        return ResponseEntity.ok(
+                authService.login(memberRequestDto)
+        );
+    }
+}

--- a/src/main/java/gift/controller/OptionController.java
+++ b/src/main/java/gift/controller/OptionController.java
@@ -1,0 +1,40 @@
+package gift.controller;
+
+import gift.dto.OptionRequestDto;
+import gift.dto.OptionsResponseDto;
+import gift.service.OptionService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/products")
+@RestController
+public class OptionController {
+
+    private final OptionService optionService;
+
+    public OptionController(OptionService optionService) {
+        this.optionService = optionService;
+    }
+
+    @GetMapping("/{productId}/options")
+    public ResponseEntity<OptionsResponseDto> getOptions(@PathVariable long productId, Pageable pageable) {
+        OptionsResponseDto optionsResponseDto = new OptionsResponseDto(
+                optionService.getProductOptions(productId, pageable)
+        );
+
+        return ResponseEntity.ok(optionsResponseDto);
+    }
+
+    @PostMapping("/{productId}/options")
+    public ResponseEntity<String> saveOption(
+            @PathVariable long productId,
+            @Validated @RequestBody OptionRequestDto optionRequestDto
+    ) {
+        optionService.saveOption(productId, optionRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body("Option is Successfully Added");
+    }
+}

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -1,0 +1,66 @@
+package gift.controller;
+
+import gift.dto.ProductRequestDto;
+import gift.dto.ProductResponseDto;
+import gift.dto.ProductStatusPatchRequestDto;
+import gift.dto.ProductsResponseDto;
+import gift.service.ProductService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/products")
+public class ProductController {
+
+    private final ProductService productService;
+
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long productId) {
+        productService.deleteProductById(productId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("")
+    public ResponseEntity<String> createProduct(
+            @Validated @RequestBody ProductRequestDto productRequestDto) {
+        Long productId = productService.saveProduct(productRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body("Successfully created id: " + productId);
+    }
+
+    @PutMapping("/{productId}")
+    public ResponseEntity<String> updateProduct(
+            @PathVariable Long productId,
+            @Validated @RequestBody ProductRequestDto productRequestDto
+    ) {
+        productService.updateProduct(productId, productRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("")
+    public ResponseEntity<ProductsResponseDto> getReadyProducts(Pageable pageable) {
+        return ResponseEntity.ok(
+                new ProductsResponseDto(productService.findReadyProducts(pageable))
+        );
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductResponseDto> getProduct(@PathVariable Long productId) {
+        return ResponseEntity.ok(productService.findProductById(productId));
+    }
+    
+    @PatchMapping("/{productId}/status")
+    public ResponseEntity<String> patchProductStatus(
+            @PathVariable Long productId,
+            @RequestBody ProductStatusPatchRequestDto statusPatchRequestDto
+            ) {
+        productService.updateProductStatus(productId, statusPatchRequestDto);
+        return ResponseEntity.ok("Successfully Update Product's Status");
+    }
+}

--- a/src/main/java/gift/controller/WishController.java
+++ b/src/main/java/gift/controller/WishController.java
@@ -1,0 +1,63 @@
+package gift.controller;
+
+import gift.config.LoginMember;
+import gift.dto.WishRequestDto;
+import gift.dto.WishesResponseDto;
+import gift.domain.Member;
+import gift.service.WishService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/wishes")
+@RestController
+public class WishController {
+
+    private final WishService wishService;
+
+    public WishController(WishService wishService) {
+        this.wishService = wishService;
+    }
+
+    @GetMapping("")
+    public ResponseEntity<WishesResponseDto> getWishList(@LoginMember Member member, Pageable pageable) {
+        return ResponseEntity.ok(
+            new WishesResponseDto(
+                    wishService.getWishList(member.getId(), pageable)
+            )
+        );
+    }
+
+    @PostMapping("/{productId}")
+    public ResponseEntity<String> saveWish(
+            @LoginMember Member member,
+            @PathVariable Long productId,
+            @RequestBody WishRequestDto wishRequestDto
+            ) {
+        wishService.saveWish(
+                member.getId(),
+                productId,
+                wishRequestDto.count()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body("Wish Successfully Created");
+    }
+
+    @PatchMapping("/{productId}")
+    public ResponseEntity<String> patchWish(
+            @LoginMember Member member,
+            @PathVariable Long productId,
+            @RequestBody WishRequestDto wishRequestDto
+    ) {
+        wishService.updateWishCount(
+                member.getId(),
+                productId,
+                wishRequestDto.count()
+        );
+
+        return ResponseEntity
+                .ok("Wish Successfully patched");
+    }
+}

--- a/src/main/java/gift/domain/Member.java
+++ b/src/main/java/gift/domain/Member.java
@@ -1,0 +1,39 @@
+package gift.domain;
+
+import org.mindrot.jbcrypt.BCrypt;
+
+public class Member {
+    private final Long id;
+    private final String email;
+    private final String passwordHash;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public boolean validatePlainPassword(String password) {
+        return BCrypt.checkpw(password, passwordHash);
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public Member(String email, String password) {
+        this.id = null;
+        this.email = email;
+        this.passwordHash = BCrypt.hashpw(
+                password,
+                BCrypt.gensalt());
+    }
+
+    public Member(Long id, String email, String passwordHash) {
+        this.id = id;
+        this.email = email;
+        this.passwordHash = passwordHash;
+    }
+}

--- a/src/main/java/gift/domain/Option.java
+++ b/src/main/java/gift/domain/Option.java
@@ -1,0 +1,44 @@
+package gift.domain;
+
+public class Option {
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    private int quantity;
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    private Product product;
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public int subtractQuantity(int quantity) {
+        if (this.quantity < quantity) {
+            throw new IllegalArgumentException("Not Enough Option Quantity");
+        }
+
+        this.quantity -= quantity;
+
+        return this.quantity;
+    }
+
+    public Option(Long id, String name, int quantity, Product product) {
+        this.id = id;
+        this.name = name;
+        this.quantity = quantity;
+        this.product = product;
+    }
+}

--- a/src/main/java/gift/domain/Product.java
+++ b/src/main/java/gift/domain/Product.java
@@ -3,9 +3,10 @@ package gift.domain;
 public class Product {
 
     public enum Status {
-        APPROVED,
-        PENDING,
-        REJECTED
+        READY, // 사용 가능 상태 [Option도 등록 완료]
+        APPROVED, // 내부 승인 됨
+        PENDING, // MD에 의해 검토 필요
+        REJECTED // MD에 의해 거절 당함
     }
 
     private Long id;
@@ -51,10 +52,10 @@ public class Product {
         this.name = name;
         this.price = price;
         this.imageUrl = imageUrl;
-        status = inferStatus(name);
+        status = inferStatusWithName(name);
     }
 
-    private Status inferStatus(String name) {
+    private Status inferStatusWithName(String name) {
         if (name.contains("카카오")) {
             return Product.Status.PENDING;
         } else {

--- a/src/main/java/gift/domain/Product.java
+++ b/src/main/java/gift/domain/Product.java
@@ -1,0 +1,64 @@
+package gift.domain;
+
+public class Product {
+
+    public enum Status {
+        APPROVED,
+        PENDING,
+        REJECTED
+    }
+
+    private Long id;
+    private String name;
+    private Integer price;
+    private String imageUrl;
+    private Status status;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getPrice() {
+        return price;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public Product(String name, int price, String imageUrl) {
+        this(null, name, price, imageUrl);
+    }
+
+    public Product(Long id, String name, int price, String imageUrl, Status status) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.status = status;
+    }
+
+    public Product(Long id, String name, int price, String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        status = inferStatus(name);
+    }
+
+    private Status inferStatus(String name) {
+        if (name.contains("카카오")) {
+            return Product.Status.PENDING;
+        } else {
+            return Product.Status.APPROVED;
+        }
+    }
+}

--- a/src/main/java/gift/domain/Wish.java
+++ b/src/main/java/gift/domain/Wish.java
@@ -1,0 +1,19 @@
+package gift.domain;
+
+public class Wish {
+    private int count;
+    private Product product;
+
+    public Wish(int count, Product product) {
+        this.count = count;
+        this.product = product;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+}

--- a/src/main/java/gift/dto/AuthResponseDto.java
+++ b/src/main/java/gift/dto/AuthResponseDto.java
@@ -1,0 +1,6 @@
+package gift.dto;
+
+public record AuthResponseDto(
+        String token
+) {
+}

--- a/src/main/java/gift/dto/MemberRequestDto.java
+++ b/src/main/java/gift/dto/MemberRequestDto.java
@@ -1,0 +1,14 @@
+package gift.dto;
+
+import gift.domain.Member;
+import jakarta.validation.constraints.Email;
+
+public record MemberRequestDto(
+        @Email
+        String email,
+        String password
+) {
+        public Member toDomain() {
+                return new Member(email, password);
+        }
+}

--- a/src/main/java/gift/dto/OptionRequestDto.java
+++ b/src/main/java/gift/dto/OptionRequestDto.java
@@ -1,14 +1,10 @@
 package gift.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import org.hibernate.validator.constraints.Length;
+import jakarta.validation.constraints.*;
 
 public record OptionRequestDto(
-        @Length(max = 50)
         @NotBlank
+        @Size(max = 50)
         @Pattern(regexp = "^[a-zA-Z0-9가-힣()\\[\\]+&/ _-]+$")
         String name,
         @Min(1)

--- a/src/main/java/gift/dto/OptionRequestDto.java
+++ b/src/main/java/gift/dto/OptionRequestDto.java
@@ -1,0 +1,18 @@
+package gift.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.Length;
+
+public record OptionRequestDto(
+        @Length(max = 50)
+        @NotBlank
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣()\\[\\]+&/ _-]+$")
+        String name,
+        @Min(1)
+        @Max(99999999)
+        int quantity
+) {
+}

--- a/src/main/java/gift/dto/OptionResponseDto.java
+++ b/src/main/java/gift/dto/OptionResponseDto.java
@@ -1,0 +1,14 @@
+package gift.dto;
+
+import gift.entity.OptionEntity;
+
+public record OptionResponseDto(
+        Long id,
+        String name,
+        int quantity
+) {
+    public OptionResponseDto(OptionEntity optionEntity) {
+        this(optionEntity.getId(), optionEntity.getName(), optionEntity.getQuantity());
+    }
+}
+

--- a/src/main/java/gift/dto/OptionsResponseDto.java
+++ b/src/main/java/gift/dto/OptionsResponseDto.java
@@ -1,0 +1,6 @@
+package gift.dto;
+
+import java.util.List;
+
+public record OptionsResponseDto(List<OptionResponseDto> options) {
+}

--- a/src/main/java/gift/dto/ProductRequestDto.java
+++ b/src/main/java/gift/dto/ProductRequestDto.java
@@ -1,0 +1,20 @@
+package gift.dto;
+
+import gift.domain.Product;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.Length;
+
+public record ProductRequestDto(
+        @Length(max = 15)
+        @Pattern(regexp= "^[a-zA-Z0-9가-힣()\\[\\]+&/ _-]+$",
+                message = "The following special characters are allowed: (), [], +, &, /, _, -]")
+        String name,
+        @Min(0) Integer price,
+        @Length(max = 255) String imageUrl) {
+
+    public Product toDomain() {
+        return new Product(name, price, imageUrl);
+    }
+}
+

--- a/src/main/java/gift/dto/ProductResponseDto.java
+++ b/src/main/java/gift/dto/ProductResponseDto.java
@@ -1,0 +1,14 @@
+package gift.dto;
+
+import gift.domain.Product;
+import gift.entity.ProductEntity;
+
+public record ProductResponseDto(Long id, String name, Integer price, String imageUrl, Product.Status status) {
+    public ProductResponseDto(Product product) {
+        this(product.getId(), product.getName(), product.getPrice(), product.getImageUrl(), product.getStatus());
+    }
+
+    public ProductResponseDto(ProductEntity productEntity) {
+        this(productEntity.getId(), productEntity.getName(), productEntity.getPrice(), productEntity.getImageUrl(), productEntity.getStatus());
+    }
+}

--- a/src/main/java/gift/dto/ProductStatusPatchRequestDto.java
+++ b/src/main/java/gift/dto/ProductStatusPatchRequestDto.java
@@ -1,0 +1,6 @@
+package gift.dto;
+
+import gift.domain.Product;
+
+public record ProductStatusPatchRequestDto(Product.Status status) {
+}

--- a/src/main/java/gift/dto/ProductsResponseDto.java
+++ b/src/main/java/gift/dto/ProductsResponseDto.java
@@ -1,0 +1,6 @@
+package gift.dto;
+
+import java.util.List;
+
+public record ProductsResponseDto(List<ProductResponseDto> products) {
+}

--- a/src/main/java/gift/dto/WishRequestDto.java
+++ b/src/main/java/gift/dto/WishRequestDto.java
@@ -1,0 +1,6 @@
+package gift.dto;
+
+public record WishRequestDto(
+        Integer count
+){
+}

--- a/src/main/java/gift/dto/WishResponseDto.java
+++ b/src/main/java/gift/dto/WishResponseDto.java
@@ -1,0 +1,7 @@
+package gift.dto;
+
+public record WishResponseDto(
+        int count,
+        ProductResponseDto productResponseDto
+) {
+}

--- a/src/main/java/gift/dto/WishesResponseDto.java
+++ b/src/main/java/gift/dto/WishesResponseDto.java
@@ -1,0 +1,6 @@
+package gift.dto;
+
+import java.util.List;
+
+public record WishesResponseDto(List<WishResponseDto> wishes) {
+}

--- a/src/main/java/gift/entity/MemberEntity.java
+++ b/src/main/java/gift/entity/MemberEntity.java
@@ -1,0 +1,43 @@
+package gift.entity;
+
+import gift.domain.Member;
+import jakarta.persistence.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "members")
+public class MemberEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 30)
+    private String email;
+
+    @Column(nullable = false, length = 60)
+    private String passwordHash;
+
+    @OneToMany(mappedBy = "memberEntity")
+    private List<WishEntity> wishEntities;
+
+    public List<WishEntity> getWishEntities() {
+        return wishEntities;
+    }
+
+    public Member toDomain() {
+        return new Member(id, email, passwordHash);
+    }
+
+    protected MemberEntity() {}
+
+    public MemberEntity(Member member) {
+        this(member.getId(), member.getEmail(), member.getPasswordHash());
+    }
+
+    public MemberEntity(Long id, String email, String passwordHash) {
+        this.id = id;
+        this.email = email;
+        this.passwordHash = passwordHash;
+    }
+}

--- a/src/main/java/gift/entity/OptionEntity.java
+++ b/src/main/java/gift/entity/OptionEntity.java
@@ -33,6 +33,10 @@ public class OptionEntity {
     @JoinColumn(name = "productId")
     private ProductEntity productEntity;
 
+    public ProductEntity getProductEntity() {
+        return productEntity;
+    }
+
     public Option toDomain() {
         return new Option(
                 id,

--- a/src/main/java/gift/entity/OptionEntity.java
+++ b/src/main/java/gift/entity/OptionEntity.java
@@ -1,0 +1,70 @@
+package gift.entity;
+
+import gift.domain.Option;
+import gift.domain.Product;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "options")
+public class OptionEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    @Column(nullable = false)
+    private int quantity;
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    @ManyToOne
+    @JoinColumn(name = "productId")
+    private ProductEntity productEntity;
+
+    public Option toDomain() {
+        return new Option(
+                id,
+                name,
+                quantity,
+                new Product(
+                        productEntity.getName(),
+                        productEntity.getPrice(),
+                        productEntity.getImageUrl())
+
+        );
+    }
+
+    protected OptionEntity() {}
+
+    public OptionEntity(String name, int quantity, ProductEntity productEntity) {
+        this(null, name, quantity, productEntity);
+    }
+
+    public OptionEntity(Option option) {
+        this(
+                option.getId(),
+                option.getName(),
+                option.getQuantity(),
+                new ProductEntity(option.getProduct())
+        );
+    }
+
+    public OptionEntity(Long id, String name, int quantity, ProductEntity productEntity) {
+        this.id = id;
+        this.name = name;
+        this.quantity = quantity;
+        this.productEntity = productEntity;
+    }
+}

--- a/src/main/java/gift/entity/ProductEntity.java
+++ b/src/main/java/gift/entity/ProductEntity.java
@@ -3,6 +3,7 @@ package gift.entity;
 import gift.domain.Product;
 import jakarta.persistence.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -43,10 +44,14 @@ public class ProductEntity {
     private Product.Status status;
 
     @OneToMany(mappedBy = "productEntity")
-    private List<OptionEntity> optionEntities;
+    private List<OptionEntity> optionEntities = new ArrayList<>();
 
     public List<OptionEntity> getOptionEntities() {
         return optionEntities;
+    }
+
+    public void addOptionEntity(OptionEntity optionEntity) {
+        optionEntities.add(optionEntity);
     }
 
     public Product.Status getStatus() {
@@ -59,6 +64,10 @@ public class ProductEntity {
 
     public boolean isApproved() {
         return status == Product.Status.APPROVED;
+    }
+
+    public boolean isPending() {
+        return status == Product.Status.PENDING;
     }
 
     protected ProductEntity() {}

--- a/src/main/java/gift/entity/ProductEntity.java
+++ b/src/main/java/gift/entity/ProductEntity.java
@@ -1,0 +1,88 @@
+package gift.entity;
+
+import gift.domain.Product;
+import jakarta.persistence.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "products")
+public class ProductEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    @Column(nullable = false, length = 15)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    @Column(nullable = false)
+    private int price;
+
+    public int getPrice() {
+        return price;
+    }
+
+    @Column(nullable = false, length = 255)
+    private String imageUrl;
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Product.Status status;
+
+    @OneToMany(mappedBy = "productEntity")
+    private List<OptionEntity> optionEntities;
+
+    public List<OptionEntity> getOptionEntities() {
+        return optionEntities;
+    }
+
+    public Product.Status getStatus() {
+        return status;
+    }
+
+    public Product toDomain() {
+        return new Product(id, name, price, imageUrl, status);
+    }
+
+    public boolean isApproved() {
+        return status == Product.Status.APPROVED;
+    }
+
+    protected ProductEntity() {}
+
+    public ProductEntity(Product product) {
+        this(product.getId(), product.getName(), product.getPrice(), product.getImageUrl(), product.getStatus());
+    }
+
+    public ProductEntity(Long id, String name, int price, String imageUrl, Product.Status status) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.status = status;
+    }
+
+    public void updateProduct(Product product) {
+        this.name = product.getName();
+        this.price = product.getPrice();
+        this.imageUrl = product.getImageUrl();
+        this.status = product.getStatus();
+    }
+
+    public void updateStatus(Product.Status status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/gift/entity/WishEntity.java
+++ b/src/main/java/gift/entity/WishEntity.java
@@ -1,0 +1,43 @@
+package gift.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "wishes")
+public class WishEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column
+    private int count;
+
+    public void updateWishCount(int count) {
+        this.count = count;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @ManyToOne
+    @JoinColumn(name = "memberId")
+    private MemberEntity memberEntity;
+
+    @ManyToOne
+    @JoinColumn(name = "productId")
+    private ProductEntity productEntity;
+
+    public ProductEntity getProductEntity() {
+        return productEntity;
+    }
+
+    protected WishEntity() {}
+
+    public WishEntity(int count, MemberEntity memberEntity, ProductEntity productEntity) {
+        this.count = count;
+        this.memberEntity = memberEntity;
+        this.productEntity = productEntity;
+    }
+}

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -1,0 +1,59 @@
+package gift.exception;
+
+import gift.util.BindingResultUtil;
+import io.jsonwebtoken.JwtException;
+import org.apache.tomcat.websocket.AuthenticationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<String> handleJwtException(JwtException e) {
+        String message = e.getMessage();
+        log.trace(message);
+        return ResponseEntity.status(
+                HttpStatus.UNAUTHORIZED)
+                .body("Unauthenticated");
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<String> handleAuthenticationException(AuthenticationException e) {
+        String message = e.getMessage();
+        log.trace(message);
+        return ResponseEntity.status(
+                        HttpStatus.UNAUTHORIZED)
+                .body("Unauthenticated");
+    }
+
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException e) {
+        String message = BindingResultUtil.getErrorMessage(e.getBindingResult());
+        log.trace(message);
+        return ResponseEntity.badRequest()
+                .body(message);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.trace(e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(e.getMessage());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleJsonParseError(HttpMessageNotReadableException e) {
+        log.trace(e.getMessage());
+        return ResponseEntity.badRequest().body("Invalid Request");
+    }
+}

--- a/src/main/java/gift/repository/MemberRepository.java
+++ b/src/main/java/gift/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package gift.repository;
+
+import gift.entity.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+    Optional<MemberEntity> findByEmail(String email);
+}

--- a/src/main/java/gift/repository/OptionRepository.java
+++ b/src/main/java/gift/repository/OptionRepository.java
@@ -1,0 +1,10 @@
+package gift.repository;
+
+import gift.entity.OptionEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OptionRepository extends JpaRepository<OptionEntity, Long> {
+    Page<OptionEntity> findAllByProductEntityId(long productId, Pageable pageable);
+}

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -1,0 +1,26 @@
+package gift.repository;
+
+import gift.domain.Product;
+import gift.entity.ProductEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
+    @EntityGraph(attributePaths = "optionEntities")
+    Optional<ProductEntity> findWithOptionsById(long id);
+
+    @Query("""
+        SELECT DISTINCT p
+        FROM ProductEntity p
+        JOIN p.optionEntities o
+        WHERE p.status = :status
+    """)
+    Page<ProductEntity> findAllByStatusHavingOptions(@Param("status") Product.Status status, Pageable pageable);
+
+}

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -13,7 +13,9 @@ import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
     @EntityGraph(attributePaths = "optionEntities")
-    Optional<ProductEntity> findWithOptionsById(long id);
+    Optional<ProductEntity> findWithOptionsById(Long id);
+
+    Page<ProductEntity> findAllByStatus(Product.Status status, Pageable pageable);
 
     @Query("""
         SELECT DISTINCT p

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,0 +1,16 @@
+package gift.repository;
+
+import gift.entity.WishEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WishRepository extends JpaRepository<WishEntity, Long> {
+    Optional<WishEntity> findWishesByMemberEntityIdAndProductEntityId(long memberId, long productId);
+
+    @EntityGraph(attributePaths = "productEntity")
+    Page<WishEntity> findByMemberEntityId(long memberId, Pageable pageable);
+}

--- a/src/main/java/gift/security/JwtPayload.java
+++ b/src/main/java/gift/security/JwtPayload.java
@@ -1,0 +1,23 @@
+package gift.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+
+public class JwtPayload {
+
+    private final Long id;
+
+    public JwtPayload(Claims claims) {
+        String idString = claims.get("sub", String.class);
+
+        if (idString.isEmpty()) {
+            throw new JwtException("NOT valid Token");
+        }
+
+        id = Long.parseLong(idString);
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/src/main/java/gift/security/JwtTokenProvider.java
+++ b/src/main/java/gift/security/JwtTokenProvider.java
@@ -1,0 +1,38 @@
+package gift.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+
+    public JwtTokenProvider(@Value("${jwt.secretKey}") String secretKey) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+    }
+
+    public String makeJwtToken(long memberId) {
+        return Jwts.builder()
+                .subject(Long.toString(memberId))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public JwtPayload parseJwtToken(String jwtToken) {
+        JwtParser parser = Jwts.parser()
+                .verifyWith(secretKey)
+                .build();
+        Claims claims = parser.parseSignedClaims(jwtToken).getPayload();
+
+        return new JwtPayload(claims);
+    }
+}
+

--- a/src/main/java/gift/service/AuthService.java
+++ b/src/main/java/gift/service/AuthService.java
@@ -1,0 +1,31 @@
+package gift.service;
+
+import gift.dto.AuthResponseDto;
+import gift.dto.MemberRequestDto;
+import gift.domain.Member;
+import gift.security.JwtTokenProvider;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthService(MemberService memberService, JwtTokenProvider jwtTokenProvider) {
+        this.memberService = memberService;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public AuthResponseDto register(MemberRequestDto memberRequestDto) {
+        Member member = memberService.creatMember(memberRequestDto);
+        String token = jwtTokenProvider.makeJwtToken(member.getId());
+        return new AuthResponseDto(token);
+    }
+
+    public AuthResponseDto login(MemberRequestDto memberRequestDto) {
+        Member member = memberService.login(memberRequestDto);
+        String token = jwtTokenProvider.makeJwtToken(member.getId());
+        return new AuthResponseDto(token);
+    }
+}

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -1,0 +1,53 @@
+package gift.service;
+
+import gift.dto.MemberRequestDto;
+import gift.domain.Member;
+import gift.entity.MemberEntity;
+import gift.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public Member getMember(long memberId) {
+        MemberEntity memberEntity = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Member 입니다."));
+
+        return memberEntity.toDomain();
+    }
+
+    public Member creatMember(MemberRequestDto memberRequestDto) {
+
+        if (memberRepository.findByEmail(memberRequestDto.email()).isPresent()){
+            throw new IllegalArgumentException("email이 중복 됩니다.");
+        }
+
+        Member member = memberRequestDto.toDomain();
+        MemberEntity memberEntity = new MemberEntity(member);
+        MemberEntity savedMemberEntity = memberRepository.save(memberEntity);
+
+        return savedMemberEntity.toDomain();
+    }
+
+    @Transactional(readOnly = true)
+    public Member login(MemberRequestDto memberRequestDto) {
+        MemberEntity memberEntity = memberRepository.findByEmail(memberRequestDto.email())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다."));
+
+        Member member = memberEntity.toDomain();
+
+        if (!member.validatePlainPassword(memberRequestDto.password())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        return member;
+    }
+}

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -1,0 +1,64 @@
+package gift.service;
+
+import gift.domain.Option;
+import gift.dto.OptionRequestDto;
+import gift.dto.OptionResponseDto;
+import gift.entity.OptionEntity;
+import gift.entity.ProductEntity;
+import gift.repository.OptionRepository;
+import gift.repository.ProductRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class OptionService {
+
+    private final OptionRepository optionRepository;
+    private final ProductRepository productRepository;
+
+    public OptionService(OptionRepository optionRepository, ProductRepository productRepository) {
+        this.optionRepository = optionRepository;
+        this.productRepository = productRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<OptionResponseDto> getProductOptions(long productId, Pageable pageable) {
+        return optionRepository.findAllByProductEntityId(productId, pageable)
+                .map(OptionResponseDto::new)
+                .toList();
+    }
+
+    public void saveOption(long productId, OptionRequestDto optionRequestDto) {
+        ProductEntity productEntity = productRepository.findWithOptionsById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("Product Not Found"));
+
+        boolean isExist = productEntity.getOptionEntities()
+                .stream().anyMatch(
+                        optionEntity -> optionEntity.getName().equals(optionRequestDto.name())
+                );
+
+        if (isExist) {
+            throw new IllegalArgumentException("Duplicated Option's name");
+        }
+
+        OptionEntity optionEntity = new OptionEntity(optionRequestDto.name(), optionRequestDto.quantity(), productEntity);
+        optionRepository.save(optionEntity);
+    }
+
+    public void subtractOptionQuantity(long optionId, int quantity) {
+        OptionEntity optionEntity = optionRepository.findById(optionId)
+                .orElseThrow(() -> new IllegalArgumentException("Option Not Found"));
+
+        Option option = optionEntity.toDomain();
+
+        int resultQuantity = option.subtractQuantity(quantity);
+
+        if (resultQuantity == 0) {
+            optionRepository.deleteById(optionId);
+        }
+    }
+}

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -1,0 +1,73 @@
+package gift.service;
+
+import gift.dto.ProductRequestDto;
+import gift.dto.ProductResponseDto;
+import gift.dto.ProductStatusPatchRequestDto;
+import gift.domain.Product;
+import gift.entity.ProductEntity;
+import gift.repository.ProductRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public ProductService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    public Long saveProduct(ProductRequestDto productRequestDto) {
+        Product product = productRequestDto.toDomain();
+        ProductEntity productEntity = new ProductEntity(product);
+        ProductEntity savedProductEntity = productRepository.save(productEntity);
+
+        return savedProductEntity.getId();
+    }
+
+    public void deleteProductById(Long id) {
+        productRepository.deleteById(id);
+    }
+
+    public void updateProduct(Long id, ProductRequestDto productRequestDto) {
+        ProductEntity productEntity = productRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Product Not Found"));
+
+        Product product = productRequestDto.toDomain();
+
+        productEntity.updateProduct(product);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductResponseDto> findReadyProducts(Pageable pageable) {
+        return productRepository.findAllByStatusHavingOptions(Product.Status.APPROVED, pageable).stream()
+                .map(ProductResponseDto::new)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductResponseDto> findAllProducts() {
+        return productRepository.findAll().stream()
+                .map(ProductResponseDto::new)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ProductResponseDto findProductById(Long id) {
+        return productRepository.findById(id)
+                .map(ProductResponseDto::new)
+                .orElseThrow(() -> new IllegalArgumentException("Product Not Found"));
+    }
+
+    public void updateProductStatus(Long productId, ProductStatusPatchRequestDto statusPatchRequestDto) {
+        ProductEntity productEntity = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("Product Not Found"));
+
+        productEntity.updateStatus(statusPatchRequestDto.status());
+    }
+}

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -45,7 +45,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public List<ProductResponseDto> findReadyProducts(Pageable pageable) {
-        return productRepository.findAllByStatusHavingOptions(Product.Status.APPROVED, pageable).stream()
+        return productRepository.findAllByStatus(Product.Status.READY, pageable).stream()
                 .map(ProductResponseDto::new)
                 .toList();
     }
@@ -69,5 +69,9 @@ public class ProductService {
                 .orElseThrow(() -> new IllegalArgumentException("Product Not Found"));
 
         productEntity.updateStatus(statusPatchRequestDto.status());
+    }
+
+    public void updateStatus() {
+
     }
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -1,0 +1,75 @@
+package gift.service;
+
+import gift.dto.ProductResponseDto;
+import gift.dto.WishResponseDto;
+import gift.entity.MemberEntity;
+import gift.entity.ProductEntity;
+import gift.entity.WishEntity;
+import gift.repository.MemberRepository;
+import gift.repository.ProductRepository;
+import gift.repository.WishRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+@Service
+public class WishService {
+
+    public final WishRepository wishRepository;
+    public final ProductRepository productRepository;
+    public final MemberRepository memberRepository;
+
+    public WishService(WishRepository wishRepository, ProductRepository productRepository, MemberRepository memberRepository) {
+        this.wishRepository = wishRepository;
+        this.productRepository = productRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    public void saveWish(long memberId, long productId, int count) {
+        if (count == 0){
+            return;
+        }
+
+        if (wishRepository.findWishesByMemberEntityIdAndProductEntityId(memberId, productId).isPresent()) {
+            throw new IllegalArgumentException("Wish is Already Existed");
+        }
+
+        MemberEntity memberEntity = memberRepository.findById(memberId)
+                        .orElseThrow(() -> new IllegalArgumentException("Member Not Found"));
+        ProductEntity productEntity = productRepository.findById(productId)
+                        .orElseThrow(() -> new IllegalArgumentException("Product Not Found"));
+        WishEntity wishEntity = new WishEntity(count, memberEntity, productEntity);
+
+        wishRepository.save(wishEntity);
+    }
+
+    public void updateWishCount(long memberId, long productId, int count) {
+        WishEntity wishEntity = wishRepository.findWishesByMemberEntityIdAndProductEntityId(memberId, productId)
+                .orElseThrow(() -> new IllegalArgumentException("Wish Not Found"));
+
+        if (count == 0) {
+            wishRepository.delete(wishEntity);
+            return;
+        }
+
+        wishEntity.updateWishCount(count);
+    }
+
+    @Transactional(readOnly = true)
+    public List<WishResponseDto> getWishList(long memberId, Pageable pageable) {
+        return wishRepository.findByMemberEntityId(memberId, pageable)
+                .map(
+                    wishEntity ->
+                            new WishResponseDto(
+                                    wishEntity.getCount(),
+                                    new ProductResponseDto(
+                                            wishEntity.getProductEntity().toDomain()
+                                    )
+                            )
+                )
+                .toList();
+    }
+}

--- a/src/main/java/gift/util/BindingResultUtil.java
+++ b/src/main/java/gift/util/BindingResultUtil.java
@@ -1,0 +1,16 @@
+package gift.util;
+
+import org.springframework.validation.BindingResult;
+
+public abstract class BindingResultUtil {
+    public static String getErrorMessage(BindingResult bindingResult) {
+        StringBuilder errorMessageBuilder = new StringBuilder();
+        bindingResult.getFieldErrors().forEach( fieldError -> {
+            errorMessageBuilder.append(fieldError.getField())
+                    .append(": ")
+                    .append(fieldError.getDefaultMessage())
+                    .append(", ");
+        });
+        return errorMessageBuilder.toString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=spring-gift

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+spring:
+  application:
+    name: spring-gift
+  thymeleaf:
+    prefix:
+      classpath:/templates/
+    suffix:
+      .html
+  h2:
+    console:
+      enabled: true
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: true
+
+  sql:
+    init:
+      schema-locations: classpath:static/sql/schema.sql
+      data-locations: classpath:static/sql/data.sql
+      mode: embedded
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:gift_database
+    username: sa
+    password:
+jwt:
+  secretKey: Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=

--- a/src/main/resources/static/js/product-options-management.js
+++ b/src/main/resources/static/js/product-options-management.js
@@ -1,0 +1,52 @@
+// Admin's options management script
+
+const modal = document.getElementById('modal');
+let modalMode = 'none';
+
+// Functions of Open and close modal
+function openModal(mode, productId = null) {
+    modalMode = mode;
+    modal.style.display = 'block';
+}
+function closeModal() {
+    modal.style.display = 'none';
+}
+
+document.getElementById('infoForm').addEventListener('submit', function(event) {
+    event.preventDefault();
+    addOption()
+});
+
+function addOption() {
+    sendOptionData(`http://localhost:8080/api/products/${product.id}/options`, 'POST');
+}
+
+function sendOptionData(url, method) {
+    const formData = new FormData(document.getElementById("infoForm"));
+    const data = Object.fromEntries(formData.entries());
+
+    fetch(url, {
+        method: method,
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(data)
+    }).then((value) => {
+        if (value.ok) {
+            onSuccess();
+        } else {
+            value.text().then(value=>{
+                onFailure(value);
+            })
+        }
+    });
+}
+
+function onSuccess() {
+    location.reload();
+    closeModal();
+}
+
+function onFailure(reason) {
+    alert(reason);
+}

--- a/src/main/resources/static/js/products-management.js
+++ b/src/main/resources/static/js/products-management.js
@@ -1,0 +1,75 @@
+// Admin's products management script
+
+const modal = document.getElementById('modal');
+const modalTitle = document.getElementById('modal-title');
+let modalMode = 'none';
+let selectedProductId = null;
+
+// Functions of Open and close modal
+function openModal(mode, productId = null) {
+    modalMode = mode;
+    modalTitle.innerText = (mode === 'add') ? '상품 추가' : '상품 수정';
+    if (mode === 'update') selectedProductId = productId;
+    modal.style.display = 'block';
+}
+function closeModal() {
+    modal.style.display = 'none';
+}
+
+document.getElementById('infoForm').addEventListener('submit', function(event) {
+    event.preventDefault();
+    if (modalMode === 'add') {
+        addProduct();
+    } else if (modalMode === 'update') {
+        updateProduct(selectedProductId);
+    }
+});
+
+// Functions communicate with the backend
+function addProduct() {
+    sendProductData('http://localhost:8080/api/products', 'POST');
+}
+
+function updateProduct(productId) {
+    sendProductData(`http://localhost:8080/api/products/${productId}`, 'PUT');
+}
+
+function deleteProduct(productId) {
+    if (productId) {
+        fetch(`http://localhost:8080/api/products/${productId}`, {
+            method: 'DELETE'
+        }).then(() => {
+            location.reload();
+        });
+    }
+}
+
+function sendProductData(url, method) {
+    const formData = new FormData(document.getElementById("infoForm"));
+    const data = Object.fromEntries(formData.entries());
+
+    fetch(url, {
+        method: method,
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(data)
+    }).then((value) => {
+        if (value.ok) {
+            onSuccess();
+        } else {
+            value.text().then(value=>{
+                onFailure(value);
+            })
+        }
+    });
+}
+
+function onSuccess() {
+    location.reload();
+    closeModal();
+}
+
+function onFailure(reason) {
+    alert(reason);
+}

--- a/src/main/resources/static/sql/data.sql
+++ b/src/main/resources/static/sql/data.sql
@@ -1,0 +1,4 @@
+INSERT INTO products (name, price, image_url, status)
+VALUES
+    ('상품 1', 3000, 'product1.png', 'APPROVED'),
+    ('상품 2', 2500, 'product2.png', 'APPROVED');

--- a/src/main/resources/static/sql/schema.sql
+++ b/src/main/resources/static/sql/schema.sql
@@ -1,0 +1,29 @@
+CREATE TABLE products (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(15) NOT NULL,
+    price INT NOT NULL,
+    image_url VARCHAR(255) NOT NULL,
+    status VARCHAR(10) NOT NULL
+);
+
+CREATE TABLE members (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    email VARCHAR(30) NOT NULL UNIQUE,
+    password_hash CHAR(60) NOT NULL
+);
+
+CREATE TABLE wishes (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    member_id BIGINT REFERENCES members(id),
+    product_id BIGINT REFERENCES products(id),
+    count INT,
+    UNIQUE (member_id, product_id)
+);
+
+CREATE TABLE options (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    product_id BIGINT NOT NULL REFERENCES products(id),
+    name VARCHAR(50) NOT NULL,
+    quantity INT NOT NULL DEFAULT 1,
+    UNIQUE (product_id, name)
+);

--- a/src/main/resources/static/style/base-style.css
+++ b/src/main/resources/static/style/base-style.css
@@ -1,0 +1,20 @@
+body {
+    font-family: 'Segoe UI', sans-serif;
+    margin: 100px;
+    background-color: #f9f9f9;
+    color: #333;
+}
+
+button {
+    padding: 6px 12px;
+    margin: 4px;
+    border: none;
+    border-radius: 4px;
+    background-color: #4A90E2;
+    color: white;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #357ABD;
+}

--- a/src/main/resources/static/style/modal-style.css
+++ b/src/main/resources/static/style/modal-style.css
@@ -1,0 +1,38 @@
+
+#modal {
+    display: none;
+    position: fixed;
+    top: 30%;
+    left: 50%;
+    transform: translate(-50%, -30%);
+    background-color: white;
+    padding: 20px;
+    border: 1px solid #ccc;
+    box-shadow: 0 0 10px rgba(0,0,0,0.2);
+    z-index: 1000;
+    border-radius: 8px;
+}
+
+#modal form input[type="text"],
+#modal form input[type="number"] {
+    width: 90%;
+    padding: 6px;
+    margin: 6px 0;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+#modal form button {
+    margin-top: 10px;
+}
+
+#modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+    z-index: 999;
+}

--- a/src/main/resources/static/style/table-style.css
+++ b/src/main/resources/static/style/table-style.css
@@ -1,0 +1,12 @@
+table {
+    width: 100%;
+    max-width: 800px;
+    margin-top: 20px;
+    border-collapse: collapse;
+}
+
+th, td {
+    padding: 10px;
+    text-align: left;
+    border: 1px solid #ccc;
+}

--- a/src/main/resources/templates/product-options.html
+++ b/src/main/resources/templates/product-options.html
@@ -1,0 +1,47 @@
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Options Management</title>
+        <link rel="stylesheet" type="text/css" href="/style/base-style.css">
+        <link rel="stylesheet" type="text/css" href="/style/table-style.css">
+        <link rel="stylesheet" type="text/css" href="/style/modal-style.css">
+        <script th:inline="javascript">
+            const product = [[${product}]];
+        </script>
+    </head>
+    <body>
+        <h1 th:text="${product.name} + '\'s Options Management'"></h1>
+        <div>
+            <button type="button" onclick="openModal('add')">Add Option</button>
+        </div>
+        <div>
+            <h2>Option List</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>옵션명</th>
+                        <th>수량</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr th:each="option : ${options}">
+                        <td th:text="${option.name()}"></td>
+                        <td th:text="${option.quantity()}"></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div id="modal">
+            <h4 id="modal-title">옵션 추가</h4>
+            <form id="infoForm">
+                <label>옵션명: <input type="text" name="name" required></label><br><br>
+                <label>수량: <input type="number" name="quantity" required step="1" min="0" max="99999999"></label><br><br>
+                <button type="submit">제출</button>
+                <button type="button" onclick="closeModal()">닫기</button>
+            </form>
+        </div>
+    </body>
+
+    <script src="/js/product-options-management.js"></script>
+</html>

--- a/src/main/resources/templates/products.html
+++ b/src/main/resources/templates/products.html
@@ -1,0 +1,56 @@
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Products Management</title>
+        <link rel="stylesheet" type="text/css" href="/style/base-style.css">
+        <link rel="stylesheet" type="text/css" href="/style/table-style.css">
+        <link rel="stylesheet" type="text/css" href="/style/modal-style.css">
+    </head>
+    <body>
+        <h1>Products Management</h1>
+        <div>
+            <button type="button" onclick="openModal('add')">Add Product</button>
+        </div>
+        <div>
+            <h2>Product List</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>상품명</th>
+                        <th>가격</th>
+                        <th>사진</th>
+                        <th>상태</th>
+                        <th>작업</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr th:each="product : ${products}">
+                        <td th:text="${product.name}"></td>
+                        <td th:text="${product.price}"></td>
+                        <td th:text="${product.imageUrl}"></td>
+                        <td th:text="${product.status}"></td>
+                        <td>
+                            <button type="button" th:onclick="openModal('update', [[${product.id}]])">Update</button> |
+                            <button type="button" th:onclick="deleteProduct([[${product.id}]])">Delete</button> |
+                            <a th:href="'/admin/products/' + ${product.id} + '/options'">Options</a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Modal for Add/Update Product -->
+        <div id="modal">
+            <h4 id="modal-title"></h4>
+            <form id="infoForm">
+                <label>상품명: <input type="text" name="name" required></label><br><br>
+                <label>가격: <input type="number" name="price" required step="1" min="0" th:max="${T(java.lang.Integer).MAX_VALUE}"></label><br><br>
+                <label>사진: <input type="text" name="imageUrl" required></label><br><br>
+                <button type="submit">제출</button>
+                <button type="button" onclick="closeModal()">닫기</button>
+            </form>
+        </div>
+    </body>
+
+    <script src="/js/products-management.js"></script>
+</html>

--- a/src/test/java/gift/controller/MemberControllerTest.java
+++ b/src/test/java/gift/controller/MemberControllerTest.java
@@ -1,0 +1,91 @@
+package gift.controller;
+
+import gift.dto.AuthResponseDto;
+import gift.dto.MemberRequestDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MemberControllerTest {
+    private final RestClient restClient = RestClient.builder().build();
+
+    @LocalServerPort
+    private int port;
+    private String baseUrl;
+
+    @BeforeEach
+    void setBaseUrl() {
+        baseUrl = "http://localhost:"+ port;
+    }
+
+    @Test
+    void 회원가입_테스트() {
+        ResponseEntity<AuthResponseDto> registerResponseEntity = registerMember("demo@demo", "pass");
+
+        assertThat(registerResponseEntity.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    @Test
+    void 로그인_성공_테스트() {
+        registerMember("loginSuccess@demo", "pass");
+
+        ResponseEntity<AuthResponseDto> loginResponseEntity = login("loginSuccess@demo", "pass");
+
+        assertThat(loginResponseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void 로그인_실패_테스트() {
+        registerMember("loginFail@demo", "pass");
+
+        HttpClientErrorException.BadRequest exception = Assertions.assertThrows(
+                HttpClientErrorException.BadRequest.class,
+                () -> login("loginFail@demo", "nontpass"));
+
+        assertThat(exception.getResponseBodyAsString()).contains("비밀번호");
+    }
+
+    @Test
+    void 회원가입_중복_이메일_테스트() {
+        ResponseEntity<AuthResponseDto> registerResponseEntity = registerMember("demo@email", "demopass");
+
+        assertThat(registerResponseEntity.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        HttpClientErrorException.BadRequest exception = Assertions.assertThrows(
+                HttpClientErrorException.BadRequest.class,
+                () -> registerMember("demo@email", "demopass"));
+
+        assertThat(exception.getResponseBodyAsString()).contains("email");
+    }
+
+    private ResponseEntity<AuthResponseDto> registerMember(String email, String password) {
+        return restClient.post()
+                .uri(baseUrl + "/api/members/register")
+                .body(new MemberRequestDto(
+                        email,
+                        password
+                ))
+                .retrieve()
+                .toEntity(AuthResponseDto.class);
+    }
+
+    private ResponseEntity<AuthResponseDto> login(String email, String password) {
+        return restClient.post()
+                .uri(baseUrl + "/api/members/login")
+                .body(new MemberRequestDto(
+                        email,
+                        password
+                ))
+                .retrieve()
+                .toEntity(AuthResponseDto.class);
+    }
+}

--- a/src/test/java/gift/controller/ProductControllerTest.java
+++ b/src/test/java/gift/controller/ProductControllerTest.java
@@ -1,0 +1,171 @@
+package gift.controller;
+
+import gift.dto.OptionRequestDto;
+import gift.dto.ProductRequestDto;
+import gift.dto.ProductResponseDto;
+import gift.domain.Product;
+import gift.dto.ProductsResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ProductControllerTest {
+
+    private final RestClient client = RestClient.builder().build();
+
+    @LocalServerPort
+    private int port;
+    private String baseUrl;
+
+    @BeforeEach
+    void setBaseUrl() {
+        baseUrl = "http://localhost:"+ port;
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidProducts")
+    void Validation_테스트(ProductRequestDto productRequestDto, List<String> messages) {
+        HttpClientErrorException.BadRequest exception = assertThrows(HttpClientErrorException.BadRequest.class,
+                () -> {
+                    addProduct(productRequestDto);
+                });
+
+        boolean anyMatch = messages.stream()
+                .anyMatch(exception.getMessage()::contains);
+
+        assertThat(anyMatch).isTrue();
+    }
+
+    Stream<Arguments> invalidProducts() {
+        return Stream.of(
+                Arguments.of(new ProductRequestDto(
+                        "1234567890123456",
+                        123,
+                        "http://~/~"
+                ), List.of("length", "길이")),
+                Arguments.of(new ProductRequestDto(
+                        "$#",
+                        123,
+                        "http://~/~"
+                ), List.of("special")),
+                Arguments.of(new ProductRequestDto(
+                        "1234567890",
+                        -1,
+                        "http://~/~"
+                ), List.of("price"))
+        );
+    }
+
+    @Test
+    void 카카오_들어가는_이름_테스트_입력_테스트() {
+        ResponseEntity<String> response = addProduct(new ProductRequestDto(
+                "카카오 들어감",
+                123,
+                "http://path/"
+        ));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        String responseMessage = response.getBody();
+        assertThat(responseMessage).isNotNull();
+
+        Pattern pattern = Pattern.compile("id: (\\d+)");
+        Matcher matcher = pattern.matcher(responseMessage);
+        Long id;
+
+        assertThat(matcher.find()).isTrue();
+
+        String idStr = matcher.group(1);
+        id = Long.parseLong(idStr);
+
+        ResponseEntity<ProductResponseDto> entity = getProduct(id);
+
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        ProductResponseDto productResponseDto = entity.getBody();
+        assertThat(productResponseDto.status()).isEqualTo(Product.Status.PENDING);
+    }
+
+    @Test
+    void 존재하는_상품_읽기_테스트() {
+        ResponseEntity<ProductResponseDto> entity = getProduct(1L);
+
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void 존재하지_않는_제폼_테스트() {
+        HttpClientErrorException.BadRequest exception = assertThrows(HttpClientErrorException.BadRequest.class,
+                () -> {
+                    getProduct(-1L);
+                });
+
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void Pagenation_Test() {
+        for (int i = 0; i < 10; i++) {
+            addProduct(new ProductRequestDto("name" + i, 123, "path"));
+            addOption(1+i, new OptionRequestDto("name" + i, 123));
+        }
+
+        ResponseEntity<ProductsResponseDto> responseEntity = getProducts(PageRequest.of(0, 5));
+
+        assertAll(
+                () -> assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () ->assertThat(responseEntity.getBody().products().size()).isEqualTo(5)
+        );
+    }
+
+    private ResponseEntity<ProductsResponseDto> getProducts(PageRequest pageRequest) {
+        return client.get()
+                .uri(baseUrl + "/api/products?"
+                + "page=" + pageRequest.getPageNumber() + "&"
+                + "size=" + pageRequest.getPageSize())
+                .retrieve()
+                .toEntity(ProductsResponseDto.class);
+    }
+
+    private ResponseEntity<String> addProduct(ProductRequestDto productRequestDto) {
+        return client.post()
+                .uri(baseUrl + "/api/products")
+                .body(productRequestDto)
+                .retrieve()
+                .toEntity(String.class);
+    }
+
+    private ResponseEntity<String> addOption(long productId, OptionRequestDto optionRequestDto) {
+        return client.post()
+                .uri(baseUrl + "/api/products/" + productId + "/options")
+                .body(optionRequestDto)
+                .retrieve()
+                .toEntity(String.class);
+    }
+
+    private ResponseEntity<ProductResponseDto> getProduct(long id) {
+        return client.get()
+                .uri(baseUrl + "/api/products/" + id)
+                .retrieve()
+                .toEntity(ProductResponseDto.class);
+    }
+}

--- a/src/test/java/gift/controller/WishControllerTest.java
+++ b/src/test/java/gift/controller/WishControllerTest.java
@@ -1,0 +1,111 @@
+package gift.controller;
+
+import gift.dto.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class WishControllerTest {
+    private final RestClient restClient = RestClient.builder().build();
+
+    @LocalServerPort
+    private int port;
+    private String baseUrl;
+
+    @BeforeEach
+    void setBaseUrl() {
+        baseUrl = "http://localhost:"+ port;
+    }
+
+    @Test
+    void Wish_추가_테스트() {
+        postProduct(new ProductRequestDto("name", 123, "path"));
+        String token = registerMemberAndGetToken("demo1@email", "asdf");
+
+        ResponseEntity<String> responseEntity = addWish(token, 1L, 234);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    @Test
+    void Wish_수정_테스트() {
+        postProduct(new ProductRequestDto("name", 123, "path"));
+        String token = registerMemberAndGetToken("demo2@email", "asdf");
+        addWish(token, 1L, 123);
+
+        ResponseEntity<String> responseEntity = updateWish(token, 1L, 321);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void Wish_GetList_테스트() {
+        postProduct(new ProductRequestDto("name", 123, "path"));
+        String token = registerMemberAndGetToken("demo3@email", "asdf");
+        addWish(token, 1L, 123);
+
+        ResponseEntity<WishesResponseDto> responseEntity = getWishList(token);
+
+        assertAll(
+                () -> assertThat(responseEntity.getBody().wishes()).isNotNull(),
+                () -> assertThat(responseEntity.getBody().wishes().size()).isGreaterThan(0),
+                () -> assertThat(responseEntity.getBody().wishes().getLast().count()).isEqualTo(123),
+                () -> assertThat(responseEntity.getBody().wishes().getLast().productResponseDto().id()).isEqualTo(1)
+        );
+    }
+
+    private String registerMemberAndGetToken(String email, String password) {
+        ResponseEntity<AuthResponseDto> registerResponseEntity = restClient.post()
+                .uri(baseUrl + "/api/members/register")
+                .body(new MemberRequestDto(email, password))
+                .retrieve()
+                .toEntity(AuthResponseDto.class);
+
+        return registerResponseEntity.getBody().token();
+    }
+
+    private ResponseEntity<String> postProduct(ProductRequestDto productRequestDto) {
+        return restClient.post()
+                .uri(baseUrl + "/api/products")
+                .body(productRequestDto)
+                .retrieve()
+                .toEntity(String.class);
+    }
+
+
+    private ResponseEntity<String> addWish(String token, Long productId, int count) {
+        return restClient.post()
+                .uri(baseUrl + "/api/wishes/" + productId)
+                .header("Authorization", "Bearer " + token)
+                .body(new WishRequestDto(count))
+                .retrieve()
+                .toEntity(String.class);
+    }
+
+    private ResponseEntity<String> updateWish(String token, Long productId, int count) {
+        return restClient.patch()
+                .uri(baseUrl + "/api/wishes/" + productId)
+                .header("Authorization", "Bearer " + token)
+                .body(new WishRequestDto(count))
+                .retrieve()
+                .toEntity(String.class);
+    }
+
+    private ResponseEntity<WishesResponseDto> getWishList(String token) {
+        return restClient.get()
+                .uri(baseUrl + "/api/wishes")
+                .header("Authorization", "Bearer " + token)
+                .retrieve()
+                .toEntity(WishesResponseDto.class);
+    }
+}

--- a/src/test/java/gift/repository/MemberRepositoryTest.java
+++ b/src/test/java/gift/repository/MemberRepositoryTest.java
@@ -1,0 +1,59 @@
+package gift.repository;
+
+import gift.entity.MemberEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+public class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void saveTest() {
+        MemberEntity memberEntity = new MemberEntity(null,"memberSave@demo", "password");
+        MemberEntity actualMemberEntity = memberRepository.save(memberEntity);
+
+        assertAll(
+                () -> assertThat(actualMemberEntity.toDomain().getId()).isNotNull(),
+                () -> assertThat(actualMemberEntity.toDomain().getEmail()).isEqualTo(memberEntity.toDomain().getEmail()),
+                () -> assertThat(actualMemberEntity.toDomain().getPasswordHash()).isEqualTo(memberEntity.toDomain().getPasswordHash())
+        );
+    }
+
+    @Test
+    void findByEmailTest() {
+        String email = "memberFindByEmail@demo";
+        MemberEntity memberEntity = new MemberEntity(null, email, "password");
+        memberRepository.save(memberEntity);
+
+        Optional<MemberEntity> optionalMemberEntity = memberRepository.findByEmail(email);
+
+        assertAll(
+                () -> assertThat(optionalMemberEntity.isPresent()).isTrue(),
+                () -> assertThat(optionalMemberEntity.get().toDomain().getEmail()).isEqualTo(email)
+        );
+    }
+
+    @Test
+    void findByIdTest() {
+        String email = "memberFindByEmail@demo";
+        MemberEntity memberEntity = new MemberEntity(null, email, "password");
+        MemberEntity savedMemberEntity = memberRepository.save(memberEntity);
+
+        Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(savedMemberEntity.toDomain().getId());
+
+        assertAll(
+                () -> assertThat(optionalMemberEntity.isPresent()).isTrue(),
+                () -> assertThat(optionalMemberEntity.get().toDomain().getEmail()).isEqualTo(email)
+        );
+    }
+}
+

--- a/src/test/java/gift/repository/OptionRepositoryTest.java
+++ b/src/test/java/gift/repository/OptionRepositoryTest.java
@@ -1,0 +1,66 @@
+package gift.repository;
+
+import gift.domain.Product;
+import gift.entity.OptionEntity;
+import gift.entity.ProductEntity;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DataJpaTest
+public class OptionRepositoryTest {
+
+    @Autowired
+    private OptionRepository optionRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void 옵션_추가_테스트() {
+        ProductEntity productEntity = productRepository.save(new ProductEntity(null, "product1", 123, "path", Product.Status.APPROVED));
+        OptionEntity optionEntity = optionRepository.save(new OptionEntity("name1", 123, productEntity));
+
+        assertThat(optionEntity.getId()).isNotNull();
+    }
+
+    @Test
+    void 옵션_이름_중복_테스트() {
+        ProductEntity productEntity = productRepository.save(new ProductEntity(null, "product1", 123, "path", Product.Status.APPROVED));
+        optionRepository.save(new OptionEntity("name1", 123, productEntity));
+
+        Assertions.assertThrows(
+                DataIntegrityViolationException.class,
+                () -> optionRepository.save(new OptionEntity("name1", 321, productEntity))
+        );
+    }
+
+    @Test
+    void 옵션_확인_테스트() {
+        ProductEntity productEntity = productRepository.save(new ProductEntity(null, "product1", 123, "path", Product.Status.APPROVED));
+        optionRepository.save(new OptionEntity("name1", 123, productEntity));
+        entityManager.flush();
+        entityManager.clear();
+        ProductEntity savedProductEntity = productRepository.findById(productEntity.getId()).get();
+
+        assertThat(savedProductEntity.getOptionEntities().size()).isEqualTo(1);
+    }
+
+    @Test
+    void 옵션_유무_필터링_테스트() {
+        int originalNum = productRepository.findAllByStatusHavingOptions(Product.Status.APPROVED, Pageable.unpaged()).getSize();
+        productRepository.save(new ProductEntity(null, "product1", 123, "path", Product.Status.APPROVED));
+        int nextNum = productRepository.findAllByStatusHavingOptions(Product.Status.APPROVED, Pageable.unpaged()).getSize();
+
+        assertThat(originalNum).isEqualTo(nextNum);
+    }
+}

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -1,0 +1,63 @@
+package gift.repository;
+
+import gift.domain.Product;
+import gift.entity.ProductEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+public class ProductRepositoryTest {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    void saveTest() {
+        ProductEntity productEntity = new ProductEntity(null,"name", 1, "/path/", Product.Status.PENDING);
+        ProductEntity actualProductEntity = productRepository.save(productEntity);
+
+        assertAll(
+                () -> assertThat(actualProductEntity.toDomain().getId()).isNotNull(),
+                () -> assertThat(actualProductEntity.toDomain().getName()).isEqualTo(productEntity.toDomain().getName()),
+                () -> assertThat(actualProductEntity.toDomain().getPrice()).isEqualTo(productEntity.toDomain().getPrice()),
+                () -> assertThat(actualProductEntity.toDomain().getImageUrl()).isEqualTo(productEntity.toDomain().getImageUrl()),
+                () -> assertThat(actualProductEntity.toDomain().getStatus()).isEqualTo(productEntity.toDomain().getStatus())
+        );
+    }
+
+    @Test
+    void findByEmailTest() {
+        ProductEntity productEntity = new ProductEntity(null,"name", 1, "/path/", Product.Status.PENDING);
+        productRepository.save(productEntity);
+
+        Optional<ProductEntity> optionalMemberEntity = productRepository.findById(productEntity.getId());
+
+        assertAll(
+                () -> assertThat(optionalMemberEntity.isPresent()).isTrue(),
+                () -> assertThat(optionalMemberEntity.get().toDomain().getId()).isNotNull(),
+                () -> assertThat(optionalMemberEntity.get().toDomain().getName()).isEqualTo(productEntity.toDomain().getName()),
+                () -> assertThat(optionalMemberEntity.get().toDomain().getPrice()).isEqualTo(productEntity.toDomain().getPrice()),
+                () -> assertThat(optionalMemberEntity.get().toDomain().getImageUrl()).isEqualTo(productEntity.toDomain().getImageUrl()),
+                () -> assertThat(optionalMemberEntity.get().toDomain().getStatus()).isEqualTo(productEntity.toDomain().getStatus())
+        );
+    }
+
+    @Test
+    void deleteTest() {
+        ProductEntity productEntity = new ProductEntity(null,"name", 1, "/path/", Product.Status.PENDING);
+        ProductEntity savedProductEntity = productRepository.save(productEntity);
+
+        productRepository.deleteById(savedProductEntity.getId());
+
+        Optional<ProductEntity> optionalProductEntity = productRepository.findById(savedProductEntity.getId());
+        assertAll(
+                () -> assertThat(optionalProductEntity.isEmpty()).isTrue()
+        );
+    }
+}

--- a/src/test/java/gift/service/OptionServiceTest.java
+++ b/src/test/java/gift/service/OptionServiceTest.java
@@ -1,0 +1,89 @@
+package gift.service;
+
+import gift.domain.Product;
+import gift.dto.OptionRequestDto;
+import gift.entity.OptionEntity;
+import gift.entity.ProductEntity;
+import gift.repository.OptionRepository;
+import gift.repository.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+public class OptionServiceTest {
+    @Mock
+    private OptionRepository optionRepository;
+    @Mock
+    private ProductRepository productRepository;
+
+    private OptionService optionService;
+
+    @Captor
+    ArgumentCaptor<OptionEntity> optionCaptor;
+
+    @BeforeEach
+    void initOptionService() {
+        optionService = new OptionService(optionRepository, productRepository);
+    }
+
+    @Test
+    void 옵션_추가_테스트() {
+        ProductEntity productEntity = new ProductEntity(
+                1L, "product 1", 123, "/path/to/image", Product.Status.APPROVED
+        );
+        given(productRepository.findWithOptionsById(any()))
+                .willReturn(Optional.of(productEntity));
+
+        optionService.saveOption(
+                1,
+                new OptionRequestDto(
+                "option 1",
+                1
+        ));
+
+        then(optionRepository).should().save(optionCaptor.capture());
+        OptionEntity savedOption = optionCaptor.getValue();
+        assertAll(
+                () -> assertThat(savedOption.getId()).isNull(),
+                () -> assertThat(savedOption.getName()).isEqualTo("option 1"),
+                () -> assertThat(savedOption.getProductEntity().getStatus()).isEqualTo(Product.Status.READY)
+        );
+    }
+
+    @Test
+    void 옵션_수_줄이기_테스트() {
+        ProductEntity productEntity = new ProductEntity(
+                1L, "product 1", 123, "/path/to/image", Product.Status.READY
+        );
+        OptionEntity optionEntity = new OptionEntity(
+                2L, "option2", 123, productEntity
+        );
+        productEntity.addOptionEntity(optionEntity);
+        given(optionRepository.findById(any()))
+                .willReturn(Optional.of(optionEntity));
+
+        optionService.subtractOptionQuantity(
+                2L,
+                123);
+
+        then(optionRepository).should().deleteById(eq(2L));
+        assertThat(productEntity.getStatus()).isEqualTo(Product.Status.APPROVED);
+    }
+}


### PR DESCRIPTION
안녕하십니까! 부산대 정윤성이라고 합니다!
일주일 동안 리뷰 잘 부탁드립니다!

## 구현 사항
* spring gift enhancement에서 코드 가져오기
* 저번 Step3 에서 받은 리뷰 반영
  * Option request Dto의 어노테이션 의존성 통일
    * jakarta.validation.*으로 의존성을 통일 시켰습니다.
      * @Length를 @Size로 수정했습니다.
  * application.yml 중복 수정
    * ddl-auto가 중복으로 설정 되어있어서 중복 제거 했습니다. 
  * Status 다양화
    * Option 유무를 따로 Status enum으로 관리 안 했었는데 관리하도록 추가했습니다.
    * Product 안에서 다 관리하는게 좋겠긴한데, DB에 접근 해야 Status를 제대로 추정할 수 있기에 지금은 Option을 등록하거나 추가할 때 관리하고 있습니다.
    * 이때 그것조차 Product domain으로 옮기면 좋겠긴한데 그렇게 되면 Product domain에 Option 객체들을 list로 항상 가지고 있어야하는데, 그게 과도한 설계라고 생각이 들어서 고민중에 있습니다. 의견 주신다면 감사히 반영해보겠습니다!
    ```
    public enum Status {
        READY, // 사용 가능 상태 [Option도 등록 완료]
        APPROVED, // 내부 승인 됨
        PENDING, // MD에 의해 검토 필요
        REJECTED // MD에 의해 거절 당함
    }
    ``` 