### PR TITLE
부산대 BE_오선재 Step1 - 카카오 로그인

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,20 @@ JWT_SECRET=
 JWT_EXPIRATION_MS=3600000
 
 # 3. 카카오 로그인 REST API 키 (Client ID)
-KAKAO_REST_API_CLIENT_ID=eb0390277e09b0ef2defdaaeea2c88a8
+rest-api.clientId=eb0390277e09b0ef2defdaaeea2c88a8
+
+# 4. 카카오 OAuth2 인증 요청을 보낼 엔드포인트
+#    - 사용자에게 로그인/동의 화면을 보여주는 URL
+kakao.auth-url=https://kauth.kakao.com
+
+# 5. 카카오 API 호출을 보낼 기본 URL
+#    - 액세스 토큰 발급, 사용자 정보 조회 등 실제 API 요청에 사용
+kakao.api-url=https://kapi.kakao.com
+
+# 6. OAuth2 Redirect URI
+#    - 카카오 로그인 후 authorization code 를 받을 콜백 URL
+#    - 반드시 Kakao Developers 콘솔에도 동일하게 등록되어 있어야 함
+kakao.redirect-uri=http://localhost:8080
 ```
 
 Jwt Secret 키는 임의의 Base64 로 인코딩된 문자열을 `JWT_SECRET=` 값에 넣어주면 됩니다.
@@ -35,40 +48,81 @@ Jwt Secret 키는 임의의 Base64 로 인코딩된 문자열을 `JWT_SECRET=` �
 
 | 환경 변수                  | 설명                         | 예시                                         |
 |----------------------------|----------------------------|---------------------------------------------|
-| `KAKAO_CLIENT_ID`          | REST API 키                  | `abcd1234abcd1234abcd1234abcd1234`         |
-| `KAKAO_CLIENT_SECRET`      | (선택) Client Secret         | `secret-xyz0987654321`                     |
-| `KAKAO_REDIRECT_URI`       | 카카오 인가 코드 콜백 URI     | `http://localhost:8080/api/members/login/kakao` |
+| `rest-api.clientId`          | REST API 키                  | `abcd1234abcd1234abcd1234abcd1234`         |
+| `kakao.redirect-uri`       | 카카오 인가 코드 콜백 URI     | `http://localhost:8080/` |
 | `JWT_SECRET`               | 서비스 JWT 서명 키           | `ZQ06uDt8FTkJrY3G2u/qAc4boHirPmQPLmRiAetJgwk=` |
 
 ---
 
 ### 🎯 기능 요구사항 체크리스트
 
-- [ ] 카카오 Developers 앱 생성 & 로그인 활성화
+- [x] 카카오 Developers 앱 생성 & 로그인 활성화
 
-- [ ] Redirect URI (/api/members/login/kakao) 등록
+- [x] Redirect URI (`http://localhost:8080/`) 등록
 
-- [ ] 환경 변수로 민감 정보 분리 (KAKAO_CLIENT_ID, JWT_SECRET 등)
+- [x] 환경 변수로 민감 정보 분리 (KAKAO_CLIENT_ID, JWT_SECRET 등)
 
-- [ ] WebClient로 인가 코드→토큰 교환 구현
+- [x] WebClient로 인가 코드→토큰 교환 구현
 
-- [ ] WebClient로 토큰→유저 정보 조회 구현
+- [x] WebClient로 토큰→유저 정보 조회 구현
 
-- [ ] JWT 발급: TokenService 재활용
+- [x] JWT 발급: TokenService 재활용
 
-- [ ] Kakao API 에러 처리
+- [x] Kakao API 에러 처리
 
-- [ ] 단위 테스트 / 통합 테스트 구현
+- [x] 단위 테스트 구현
 
 ---
 
 ### 🗺️ HTTP API
 
-| 메서드 | 경로                                           | 설명                                                                                 |
-|--------|-----------------------------------------------|--------------------------------------------------------------------------------------|
-| GET    | `/login/kakao`                                 | 카카오 로그인 버튼 클릭 → 카카오 인가 URL로 리다이렉트                                    |
-| GET    | `/`                                            | **Redirect URI** (`http://localhost:8080`) 콜백<br/>`code` 파라미터가 있으면 내부 API로 포워딩 |
-| GET    | `/api/members/login/kakao?code={authorization}` | 인가 코드 수신 → WebClient로 토큰 교환 → 사용자 정보 조회 → JWT 생성 → JSON 응답               |
+1. 프론트엔드(Thymeleaf) 엔드포인트
+
+|  메서드  | 경로       | 설명                              | 반환                            |
+| :---: | :------- | :------------------------------ | :---------------------------- |
+| `GET` | `/login` | 로그인 페이지 렌더링<br/>– 카카오 로그인 버튼 포함 | `templates/auth/login.html` 뷰 |
+
+2. OAuth 콜백 처리 엔드포인트
+
+|  메서드  | 경로  | 쿼리 파라미터           | 설명                                       | 동작                                             |
+| :---: | :-- | :---------------- | :--------------------------------------- | :--------------------------------------------- |
+| `GET` | `/` | `code` (optional) | 카카오로부터 인가 코드를 전달받는 콜백<br/>(Redirect URI) | 1. `code` 있으면 로그인<br/>2. 없으면 `/login` 으로 리다이렉트 |
+
+3. 내부 서비스 간 HTTP 호출
+    - 토큰 교환 (Authorization Code → Access Token)
+        - 메서드: `POST {kakao.auth-url}/oauth/token`
+        - Content-Type: `application/x-www-form-urlencoded `
+        - 폼 필드:
+           ```ini
+           grant_type=authorization_code
+           client_id={REST_API_KEY}
+           redirect_uri={CALLBACK_URL}
+           code={인가 코드}
+           ```
+        - 응답 바인딩: `KakaoTokenResponseDto`
+           ```json
+           {
+              "access_token":"AAA",
+              "refresh_token":"RRR",
+              "expires_in":3600,
+              "token_type":"Bearer"
+           }
+           ```
+    - 사용자 정보 조회
+        - 메서드: `GET {kakao.api-url}/v2/user/me`
+        - 헤더:
+           ```ini
+           Authorization: Bearer {access_token}
+           ```
+        - 응답 바인딩: `KakaoUserResponseDto`
+           ```json
+           {
+             "id": 999,
+             "kakao_account": {
+               "profile": { "nickname": "Neo" }
+             }
+           }
+            ```
 
 ---
 
@@ -76,8 +130,8 @@ Jwt Secret 키는 임의의 Base64 로 인코딩된 문자열을 `JWT_SECRET=` �
 
 ```text
 https://kauth.kakao.com/oauth/authorize
-  ?client_id=${KAKAO_CLIENT_ID}
-  &redirect_uri=${KAKAO_REDIRECT_URI}    # http://localhost:8080
+  ?client_id=${rest-api.clientId}
+  &redirect_uri=${kakao.redirect-uri}    # http://localhost:8080
   &response_type=code
-  &scope=account_email,profile_nickname
+  &scope=profile_nickname
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
 # spring-gift-order
+
+### .env 파일 준비
+
+프로젝트 루트에 `.env` 파일이 존재해야 프로젝트가 정상 실행됩니다.
+
+프로젝트 루트에 `.env` 파일을 생성하고, 아래 항목을 추가합니다.
+
+```bash
+# 1. JWT Secret 키 (Base64 인코딩된 문자열)
+JWT_SECRET=
+
+# 2. JWT 만료시간 (밀리초 단위)
+JWT_EXPIRATION_MS=3600000
+
+# 3. 카카오 로그인 REST API 키 (Client ID)
+KAKAO_REST_API_CLIENT_ID=eb0390277e09b0ef2defdaaeea2c88a8
+```
+
+Jwt Secret 키는 임의의 Base64 로 인코딩된 문자열을 `JWT_SECRET=` 값에 넣어주면 됩니다.
+
+---
+
+## 이전 미션 `README.md`
+
+### Spring-gift-product `README.md` - https://github.com/5seonjae/spring-gift-product/blob/step3/README.md
+### Spring-gift-wishlist `README.md` - https://github.com/5seonjae/spring-gift-wishlist/blob/step3/README.md
+### Spring-gift-enhancement `README.md` - https://github.com/5seonjae/spring-gift-enhancement/blob/step3/README.md
+
+---
+
+## 🚀 Step 1 – 카카오 로그인
+
+### ⚙️ 환경 변수(.env 또는 IDE 설정)
+
+| 환경 변수                  | 설명                         | 예시                                         |
+|----------------------------|----------------------------|---------------------------------------------|
+| `KAKAO_CLIENT_ID`          | REST API 키                  | `abcd1234abcd1234abcd1234abcd1234`         |
+| `KAKAO_CLIENT_SECRET`      | (선택) Client Secret         | `secret-xyz0987654321`                     |
+| `KAKAO_REDIRECT_URI`       | 카카오 인가 코드 콜백 URI     | `http://localhost:8080/api/members/login/kakao` |
+| `JWT_SECRET`               | 서비스 JWT 서명 키           | `ZQ06uDt8FTkJrY3G2u/qAc4boHirPmQPLmRiAetJgwk=` |
+
+---
+
+### 🎯 기능 요구사항 체크리스트
+
+- [ ] 카카오 Developers 앱 생성 & 로그인 활성화
+
+- [ ] Redirect URI (/api/members/login/kakao) 등록
+
+- [ ] 환경 변수로 민감 정보 분리 (KAKAO_CLIENT_ID, JWT_SECRET 등)
+
+- [ ] WebClient로 인가 코드→토큰 교환 구현
+
+- [ ] WebClient로 토큰→유저 정보 조회 구현
+
+- [ ] JWT 발급: TokenService 재활용
+
+- [ ] Kakao API 에러 처리
+
+- [ ] 단위 테스트 / 통합 테스트 구현
+
+---
+
+### 🗺️ HTTP API
+
+| 메서드 | 경로                                           | 설명                                                                                 |
+|--------|-----------------------------------------------|--------------------------------------------------------------------------------------|
+| GET    | `/login/kakao`                                 | 카카오 로그인 버튼 클릭 → 카카오 인가 URL로 리다이렉트                                    |
+| GET    | `/`                                            | **Redirect URI** (`http://localhost:8080`) 콜백<br/>`code` 파라미터가 있으면 내부 API로 포워딩 |
+| GET    | `/api/members/login/kakao?code={authorization}` | 인가 코드 수신 → WebClient로 토큰 교환 → 사용자 정보 조회 → JWT 생성 → JSON 응답               |
+
+---
+
+### 인가 URL 예시
+
+```text
+https://kauth.kakao.com/oauth/authorize
+  ?client_id=${KAKAO_CLIENT_ID}
+  &redirect_uri=${KAKAO_REDIRECT_URI}    # http://localhost:8080
+  &response_type=code
+  &scope=account_email,profile_nickname
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ JWT_SECRET=
 JWT_EXPIRATION_MS=3600000
 
 # 3. 카카오 로그인 REST API 키 (Client ID)
-rest-api.clientId=eb0390277e09b0ef2defdaaeea2c88a8
+kakao.clientId=
 
 # 4. 카카오 OAuth2 인증 요청을 보낼 엔드포인트
 #    - 사용자에게 로그인/동의 화면을 보여주는 URL
@@ -31,6 +31,9 @@ kakao.redirect-uri=http://localhost:8080
 ```
 
 Jwt Secret 키는 임의의 Base64 로 인코딩된 문자열을 `JWT_SECRET=` 값에 넣어주면 됩니다.
+
+``kakao.client-id`` 에는 **앱의 REST API 키** 를 입력합니다.  
+이 값은 개인‧프로덕션 자격 증명이므로 **절대로 Git 레포지토리에 커밋하거나 공개 저장소에 노출하지 마세요.**
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly  'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.12.6'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/gift/controller/api/MemberController.java
+++ b/src/main/java/gift/controller/api/MemberController.java
@@ -28,7 +28,6 @@ public class MemberController {
         this.basicAuthHeaderParser = basicAuthHeaderParser;
     }
 
-    // 회원 생성
     @PostMapping()
     public ResponseEntity<MemberRegisterResponseDto> createMember(
         @RequestBody @Valid MemberRegisterRequestDto requestDto

--- a/src/main/java/gift/controller/api/ProductController.java
+++ b/src/main/java/gift/controller/api/ProductController.java
@@ -38,31 +38,29 @@ public class ProductController {
         return new ResponseEntity<>(saved, HttpStatus.CREATED);
     }
 
-    // 상품 전체 조회
     @GetMapping
     public ResponseEntity<Page<Product>> getAllProducts(
         @PageableDefault(size = 5, sort = "id", direction = DESC) Pageable pageable
     ) {
         Page<Product> products = productService.getAllProducts(pageable);
-        return ResponseEntity.ok(products);  // 200 OK + JSON 배열
+        return ResponseEntity.ok(products);
     }
 
-    // 상품 개별 조회
     @GetMapping("/{id}")
     public ResponseEntity<Product> getProduct(@PathVariable long id) {
         Product product = productService.getProductById(id);
-        return ResponseEntity.ok(product); // 200 OK
+        return ResponseEntity.ok(product);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<Product> updateProduct(@PathVariable long id, @RequestBody @Valid ProductUpdateRequestDto updateRequestDto) {
         Product updated = productService.updateProduct(id, updateRequestDto);
-        return ResponseEntity.ok(updated); // 200 OK
+        return ResponseEntity.ok(updated);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteProduct(@PathVariable long id) {
         productService.deleteProduct(id);
-        return ResponseEntity.noContent().build(); // 204 No Content
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/gift/controller/view/AdminProductViewController.java
+++ b/src/main/java/gift/controller/view/AdminProductViewController.java
@@ -35,7 +35,6 @@ public class AdminProductViewController {
         this.optionService = optionService;
     }
 
-    // 상품 목록 화면
     @GetMapping
     public String getProducts(
         Model model,
@@ -46,14 +45,12 @@ public class AdminProductViewController {
         return "products/admin/list";
     }
 
-    // 상품 등록 폼 화면
     @GetMapping("/new")
     public String showCreateForm(Model model) {
         model.addAttribute("productRequest", new ProductViewRequestDto());
         return "products/admin/form";
     }
 
-    // 상품 등록 요청 처리
     @PostMapping("/new")
     public String createProduct(
         @Valid @ModelAttribute("productRequest") ProductViewRequestDto request,
@@ -79,7 +76,6 @@ public class AdminProductViewController {
         }
     }
 
-    // 상품 개별 조회 요청 처리
     @GetMapping("/{id}")
     public String viewProductDetail(@PathVariable Long id,
         Model model,
@@ -97,7 +93,6 @@ public class AdminProductViewController {
         }
     }
 
-    // 상품 수정 폼 보여주기
     @GetMapping("/{id}/edit")
     public String showEditForm(@PathVariable Long id, Model model) {
         Product product = productService.getProductById(id);
@@ -113,7 +108,6 @@ public class AdminProductViewController {
         return "products/admin/form";
     }
 
-    // 상품 수정 요청 처리
     @PostMapping("/{id}/edit")
     public String updateProduct(@PathVariable Long id,
         @Valid @ModelAttribute("productRequest") ProductViewRequestDto dto,
@@ -125,7 +119,6 @@ public class AdminProductViewController {
         }
 
         try {
-            // dto를 변환해서 넘김
             ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
                 dto.getName(), dto.getPrice(), dto.getImageUrl()
             );
@@ -133,14 +126,12 @@ public class AdminProductViewController {
             productService.updateProduct(id, updateDto);
             return "redirect:/admin/products";
         } catch (IllegalArgumentException e) {
-            // 예외 메세지를 모델에 추가
             model.addAttribute("errorMessage", e.getMessage());
             return "products/admin/form";
         }
 
     }
 
-    // 상품 삭제 요청 처리
     @PostMapping("/{id}/delete")
     public String deleteProduct(@PathVariable Long id) {
         productService.deleteProduct(id); // 서비스 재사용

--- a/src/main/java/gift/controller/view/AuthViewController.java
+++ b/src/main/java/gift/controller/view/AuthViewController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import java.io.IOException;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -97,10 +98,14 @@ public class AuthViewController {
         if (code != null) {
             String jwt = memberService.loginWithKakao(code);
 
-            Cookie authCookie = new Cookie("AUTH", jwt);
-            authCookie.setHttpOnly(true);
-            authCookie.setPath("/");
-            response.addCookie(authCookie);
+            ResponseCookie cookie = ResponseCookie.from("AUTH", jwt)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofHours(1))
+                .sameSite("Lax")
+                .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
             response.sendRedirect("/products");
         } else {

--- a/src/main/java/gift/controller/view/AuthViewController.java
+++ b/src/main/java/gift/controller/view/AuthViewController.java
@@ -89,32 +89,21 @@ public class AuthViewController {
         return "redirect:/login";
     }
 
-    /**
-     * 카카오 OAuth 콜백 처리
-     * - Redirect URI로 "/" 만 등록했을 때
-     * - code 파라미터가 있으면 토큰 교환 → JWT 발급 → HttpOnly 쿠키에 담아 루트로 리다이렉트
-     * - 없으면 로그인 페이지로 리다이렉트
-     */
     @GetMapping("/")
     public void kakaoCallback(
         @RequestParam(value = "code", required = false) String code,
         HttpServletResponse response
     ) throws IOException {
         if (code != null) {
-            // 1) 인가 코드 → JWT
             String jwt = memberService.loginWithKakao(code);
 
-            // 2) HttpOnly 쿠키에 JWT 담기
             Cookie authCookie = new Cookie("AUTH", jwt);
             authCookie.setHttpOnly(true);
             authCookie.setPath("/");
-            // 필요하다면 secure, maxAge 등 추가 설정
             response.addCookie(authCookie);
 
-            // 3) 로그인 후 메인 페이지(또는 원하는 URL)로
             response.sendRedirect("/products");
         } else {
-            // code 없으면 /login 화면으로
             response.sendRedirect("/login");
         }
     }

--- a/src/main/java/gift/controller/view/AuthViewController.java
+++ b/src/main/java/gift/controller/view/AuthViewController.java
@@ -95,21 +95,20 @@ public class AuthViewController {
         @RequestParam(value = "code", required = false) String code,
         HttpServletResponse response
     ) throws IOException {
-        if (code != null) {
-            String jwt = memberService.loginWithKakao(code);
-
-            ResponseCookie cookie = ResponseCookie.from("AUTH", jwt)
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
-                .maxAge(Duration.ofHours(1))
-                .sameSite("Lax")
-                .build();
-            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-
-            response.sendRedirect("/products");
-        } else {
+        if (code == null) {
             response.sendRedirect("/login");
+            return;
         }
+
+        String jwt = memberService.loginWithKakao(code);
+        ResponseCookie cookie = ResponseCookie.from("AUTH", jwt)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .maxAge(Duration.ofHours(1))
+            .sameSite("Lax")
+            .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        response.sendRedirect("/products");
     }
 }

--- a/src/main/java/gift/controller/view/AuthViewController.java
+++ b/src/main/java/gift/controller/view/AuthViewController.java
@@ -3,8 +3,10 @@ package gift.controller.view;
 import gift.dto.api.MemberRegisterRequestDto;
 import gift.exception.InvalidCredentialsException;
 import gift.service.MemberService;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
@@ -85,5 +87,35 @@ public class AuthViewController {
                 .build()
                 .toString());
         return "redirect:/login";
+    }
+
+    /**
+     * 카카오 OAuth 콜백 처리
+     * - Redirect URI로 "/" 만 등록했을 때
+     * - code 파라미터가 있으면 토큰 교환 → JWT 발급 → HttpOnly 쿠키에 담아 루트로 리다이렉트
+     * - 없으면 로그인 페이지로 리다이렉트
+     */
+    @GetMapping("/")
+    public void kakaoCallback(
+        @RequestParam(value = "code", required = false) String code,
+        HttpServletResponse response
+    ) throws IOException {
+        if (code != null) {
+            // 1) 인가 코드 → JWT
+            String jwt = memberService.loginWithKakao(code);
+
+            // 2) HttpOnly 쿠키에 JWT 담기
+            Cookie authCookie = new Cookie("AUTH", jwt);
+            authCookie.setHttpOnly(true);
+            authCookie.setPath("/");
+            // 필요하다면 secure, maxAge 등 추가 설정
+            response.addCookie(authCookie);
+
+            // 3) 로그인 후 메인 페이지(또는 원하는 URL)로
+            response.sendRedirect("/products");
+        } else {
+            // code 없으면 /login 화면으로
+            response.sendRedirect("/login");
+        }
     }
 }

--- a/src/main/java/gift/controller/view/ProductViewController.java
+++ b/src/main/java/gift/controller/view/ProductViewController.java
@@ -30,7 +30,6 @@ public class ProductViewController {
         this.optionService = optionService;
     }
 
-    // 상품 목록 화면
     @GetMapping
     public String getProducts(
         Model model,
@@ -41,7 +40,6 @@ public class ProductViewController {
         return "products/user/list";
     }
 
-    // 상품 개별 조회 요청 처리
     @GetMapping("/{id}")
     public String viewProductDetail(@PathVariable Long id,
         Model model,

--- a/src/main/java/gift/controller/view/WishViewController.java
+++ b/src/main/java/gift/controller/view/WishViewController.java
@@ -47,7 +47,7 @@ public class WishViewController {
     ) {
         wishService.addWishItemForMember(member, new WishRequestDto(productId, 1));
         ra.addFlashAttribute("msg", "위시 리스트에 담겼습니다!");
-        return "redirect:/products";            // 상품 목록으로 되돌리거나 /wishes 로
+        return "redirect:/products";
     }
 
     @PostMapping("/{productId}/delete")

--- a/src/main/java/gift/dto/api/KakaoTokenResponseDto.java
+++ b/src/main/java/gift/dto/api/KakaoTokenResponseDto.java
@@ -1,11 +1,12 @@
 package gift.dto.api;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-public record KakaoTokenResponseDto (
-    @JsonProperty("access_token") String accessToken,
-    @JsonProperty("refresh_token") String refreshToken,
-    @JsonProperty("expires_in") long expiresIn,
-    @JsonProperty("token_type") String tokenType
-) {
-}
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoTokenResponseDto(
+    String accessToken,
+    String refreshToken,
+    long expiresIn,
+    String tokenType
+) {}

--- a/src/main/java/gift/dto/api/KakaoTokenResponseDto.java
+++ b/src/main/java/gift/dto/api/KakaoTokenResponseDto.java
@@ -1,0 +1,11 @@
+package gift.dto.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponseDto (
+    @JsonProperty("access_token") String accessToken,
+    @JsonProperty("refresh_token") String refreshToken,
+    @JsonProperty("expires_in") long expiresIn,
+    @JsonProperty("token_type") String tokenType
+) {
+}

--- a/src/main/java/gift/dto/api/KakaoUserResponseDto.java
+++ b/src/main/java/gift/dto/api/KakaoUserResponseDto.java
@@ -1,0 +1,15 @@
+package gift.dto.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public record KakaoUserResponseDto (
+    long id,
+    @JsonProperty("kakao_account") Map<String,Object> account
+) {
+
+    public String nickname() {
+        Map<String,Object> profile = (Map<String,Object>) account.get("profile");
+        return profile == null ? null : (String) profile.get("nickname");
+    }
+}

--- a/src/main/java/gift/dto/api/ProductUpdateRequestDto.java
+++ b/src/main/java/gift/dto/api/ProductUpdateRequestDto.java
@@ -30,7 +30,6 @@ public class ProductUpdateRequestDto {
     @NotBlank(message = "이미지 URL은 필수입니다.", groups = NotBlankCheck.class)
     private String imageUrl;
 
-    // 생성자 추가
     public ProductUpdateRequestDto(String name, Integer price, String imageUrl) {
         this.name = name;
         this.price = price;

--- a/src/main/java/gift/dto/view/ProductViewRequestDto.java
+++ b/src/main/java/gift/dto/view/ProductViewRequestDto.java
@@ -23,11 +23,9 @@ public class ProductViewRequestDto {
     @NotBlank(message = "이미지 URL을 입력해주세요.")
     private String imageUrl;
 
-    // 기본 생성자
     public ProductViewRequestDto() {
     }
 
-    // Getter / Setter
     public String getName() {
         return name;
     }

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -19,14 +19,18 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String email;
 
-    @Column(nullable = false)
     private String password;
 
     @Column(name = "is_admin", nullable = false)
     private boolean isAdmin = false;
+
+    @Column(unique = true)
+    private Long kakaoId;
+
+    private String nickname;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WishItem> wishItems = new ArrayList<>();
@@ -43,6 +47,14 @@ public class Member {
 
     public Member(String email, String password) {
         this(null, email, password);
+    }
+
+    public Member(Long kakaoId, String nickname) {
+        if (kakaoId == null) {
+            throw new IllegalArgumentException("카카오 ID는 필수입니다.");
+        }
+        this.kakaoId  = kakaoId;
+        this.nickname = nickname;
     }
 
     private void validate(String email, String password) {
@@ -79,5 +91,13 @@ public class Member {
 
     public boolean getIsAdmin() {
         return isAdmin;
+    }
+
+    public Long getKakaoId() {
+        return kakaoId;
+    }
+
+    public String getNickname() {
+        return nickname;
     }
 }

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -62,8 +62,6 @@ public class Member {
             throw new IllegalArgumentException("이메일은 필수입니다.");
         }
 
-        // ".+@.+\\..+" : something@something.something 형태
-        // '.+' : 1자 이상의 아무 문자 / '@' : 반드시 @ 존재 / '\\.' 반드시 . 존재
         if (!email.matches(".+@.+\\..+")) {
             throw new IllegalArgumentException("유효한 이메일 형식이 아닙니다.");
         }

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -31,10 +31,6 @@ public class Product {
     protected Product() {
     }
 
-    /**
-     * DB에서 자동 생성되는 ID를 포함한 전체 필드 생성자 등록 시에는 id가 null 이므로 Long 으로 처리 Product는 불변 객체이기 때문에 생성자에서 모든
-     * 필드를 설정함
-     */
     public Product(Long id, String name, int price, String imageUrl) {
         validate(name, price, imageUrl);
 

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -1,18 +1,21 @@
 package gift.exception;
 
 import com.fasterxml.jackson.databind.JsonMappingException.Reference;
+import java.net.SocketTimeoutException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.dao.DuplicateKeyException;
 
@@ -135,9 +138,43 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(KakaoOAuthException.class)
     public ResponseEntity<ProblemDetail> handleKakaoOAuth(KakaoOAuthException ex) {
-        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_GATEWAY);
+        HttpStatusCode upstream = ex.getStatusCode();
+        HttpStatus status = mapToStatus(upstream);
+
+        ProblemDetail pd = ProblemDetail.forStatus(status);
         pd.setTitle("카카오 OAuth 처리 오류");
         pd.setDetail(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(pd);
+        return ResponseEntity.status(status).body(pd);
+    }
+
+    @ExceptionHandler(ResourceAccessException.class)
+    public ResponseEntity<ProblemDetail> handleTimeout(ResourceAccessException ex) {
+        if (ex.getCause() instanceof SocketTimeoutException) {
+            ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.GATEWAY_TIMEOUT);
+            pd.setTitle("카카오 OAuth 타임아웃");
+            pd.setDetail("카카오 API 호출이 시간 내에 응답하지 못했습니다.");
+            return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT).body(pd);
+        }
+        return handleInternal(ex);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ProblemDetail> handleInternal(Exception ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        pd.setTitle("서버 내부 오류");
+        pd.setDetail(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(pd);
+    }
+
+    private HttpStatus mapToStatus(HttpStatusCode upstream) {
+        if (upstream.is4xxClientError()) {
+            return (upstream.value() == HttpStatus.UNAUTHORIZED.value()
+                ? HttpStatus.UNAUTHORIZED
+                : HttpStatus.BAD_REQUEST);
+        }
+        if (upstream.is5xxServerError()) {
+            return HttpStatus.BAD_GATEWAY;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
     }
 }

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -137,5 +138,13 @@ public class GlobalExceptionHandler {
         Map<String, String> error = new HashMap<>();
         error.put("error", e.getMessage());
         return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(KakaoOAuthException.class)
+    public ResponseEntity<ProblemDetail> handleKakaoOAuth(KakaoOAuthException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_GATEWAY);
+        pd.setTitle("카카오 OAuth 처리 오류");
+        pd.setDetail(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(pd);
     }
 }

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -33,12 +33,11 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
     }
 
-    // PathVariable/RequestParam 타입 불일치 시 예외를 처리할 핸들러
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<Map<String, String>> handleTypeMismatch(
         MethodArgumentTypeMismatchException e) {
         Map<String, String> errors = new HashMap<>();
-        String field = e.getName();             // "id" 같은 파라미터 이름
+        String field = e.getName();
         String requiredType = e.getRequiredType() != null
             ? e.getRequiredType().getSimpleName()
             : "유효한 타입";
@@ -47,7 +46,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
-    // JSON 바디 파싱 오류(HttpMessageNotReadableException) 예외 처리 핸들러
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<Map<String, String>> handleHttpMessageNotReadable(
         HttpMessageNotReadableException e) {
@@ -57,12 +55,12 @@ public class GlobalExceptionHandler {
         Throwable cause = e.getCause();
 
         if (cause instanceof com.fasterxml.jackson.databind.exc.MismatchedInputException mie) {
-            // Jackson이 파싱에 실패한 필드 이름 추출
+
             String field = mie.getPath().stream()
                 .map(Reference::getFieldName)
                 .filter(Objects::nonNull)
                 .collect(Collectors.joining("."));
-            // 기대 타입 이름
+
             String targetType = (mie.getTargetType() != null)
                 ? mie.getTargetType().getSimpleName()
                 : "유효한 타입";
@@ -74,7 +72,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
-    // 유효성 검사 실패 시 예외를 처리할 핸들러
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationErrors(
         MethodArgumentNotValidException e) {
@@ -84,7 +81,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
-    // 중복 이메일 예외를 처리할 핸들러
     @ExceptionHandler(DuplicateKeyException.class)
     public ResponseEntity<Map<String, String>> handleDuplicateEmail(DuplicateKeyException e) {
         Map<String, String> error = new HashMap<>();
@@ -92,7 +88,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(error, HttpStatus.CONFLICT);
     }
 
-    // 이메일, 비밀번호 불일치 예외를 처리할 핸들러
     @ExceptionHandler(InvalidCredentialsException.class)
     public ResponseEntity<Map<String, String>> handleInvalidCredentials(
         InvalidCredentialsException e) {
@@ -101,7 +96,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
     }
 
-    // 헤더 누락 예외를 처리할 핸들러
     @ExceptionHandler(MissingAuthorizationHeaderException.class)
     public ResponseEntity<Map<String, String>> handleMissingHeader(
         MissingAuthorizationHeaderException e) {
@@ -110,7 +104,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
     }
 
-    // 헤더 형식 오류 예외를 처리할 핸들러
     @ExceptionHandler(InvalidAuthorizationHeaderException.class)
     public ResponseEntity<Map<String, String>> handleMissingHeader(
         InvalidAuthorizationHeaderException e) {

--- a/src/main/java/gift/exception/KakaoOAuthException.java
+++ b/src/main/java/gift/exception/KakaoOAuthException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class KakaoOAuthException extends RuntimeException {
+
+    public KakaoOAuthException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/exception/KakaoOAuthException.java
+++ b/src/main/java/gift/exception/KakaoOAuthException.java
@@ -1,8 +1,16 @@
 package gift.exception;
 
-public class KakaoOAuthException extends RuntimeException {
+import org.springframework.http.HttpStatusCode;
 
-    public KakaoOAuthException(String message) {
+public class KakaoOAuthException extends RuntimeException {
+    private final HttpStatusCode statusCode;
+
+    public KakaoOAuthException(HttpStatusCode statusCode, String message) {
         super(message);
+        this.statusCode = statusCode;
+    }
+
+    public HttpStatusCode getStatusCode() {
+        return statusCode;
     }
 }

--- a/src/main/java/gift/repository/ApprovedProductRepository.java
+++ b/src/main/java/gift/repository/ApprovedProductRepository.java
@@ -7,6 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ApprovedProductRepository extends JpaRepository<ApprovedProduct, Long> {
 
-    // 승인 여부 확인
     boolean existsByName(String name);
 }

--- a/src/main/java/gift/repository/MemberRepository.java
+++ b/src/main/java/gift/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByKakaoId(Long kakaoId);
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -11,11 +11,9 @@ import java.util.List;
 
 public interface WishRepository extends JpaRepository<WishItem, Long> {
 
-    // 페이징용 메서드
     @EntityGraph(attributePaths = "product")
     Page<WishItem> findAllByMemberId(Long memberId, Pageable pageable);
 
-    // 리스트 조회용 메서드
     @EntityGraph(attributePaths = "product")
     List<WishItem> findAllByMemberId(Long memberId);
 

--- a/src/main/java/gift/service/KakaoOAuthService.java
+++ b/src/main/java/gift/service/KakaoOAuthService.java
@@ -1,0 +1,81 @@
+package gift.service;
+
+import gift.dto.api.KakaoTokenResponseDto;
+import gift.dto.api.KakaoUserResponseDto;
+import gift.exception.KakaoOAuthException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class KakaoOAuthService {
+
+    @Value("${rest-api.clientId}")
+    private final String clientId;
+
+    @Value("${kakao.auth-url}")
+    private final String authUrl;
+
+    @Value("${kakao.api-url}")
+    private final String apiUrl;
+
+    @Value("${kakao.redirect-uri:}")
+    private final String redirectUri;
+
+    private final WebClient webClient;
+
+    public KakaoOAuthService(
+        @Value("${rest-api.clientId}") String clientId,
+        @Value("${kakao.auth-url}") String authUrl,
+        @Value("${kakao.api-url}") String apiUrl,
+        @Value("${kakao.redirect-uri:}") String redirectUri,
+        WebClient.Builder builder
+    ) {
+        this.clientId   = clientId;
+        this.authUrl    = authUrl;
+        this.apiUrl     = apiUrl;
+        this.redirectUri= redirectUri;
+        this.webClient = builder.build();
+    }
+
+    public KakaoTokenResponseDto exchangeCodeForToken(String code) {
+        return webClient.post()
+            .uri(authUrl + "/oauth/token")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(BodyInserters
+                .fromFormData("grant_type", "authorization_code")
+                .with("client_id", clientId)
+                .with("redirect_uri", redirectUri)
+                .with("code", code))
+            .retrieve()
+            .onStatus(HttpStatusCode::isError, resp ->
+                resp.bodyToMono(String.class)
+                    .flatMap(body -> Mono.error(
+                        new KakaoOAuthException(
+                            "토큰 교환 실패: " + resp.statusCode() + " - " + body)
+                    ))
+            )
+            .bodyToMono(KakaoTokenResponseDto.class)
+            .block();
+    }
+
+    public KakaoUserResponseDto fetchUserInfo(String accessToken) {
+        return webClient.get()
+            .uri(apiUrl + "/v2/user/me")
+            .header("Authorization", "Bearer " + accessToken)
+            .retrieve()
+            .onStatus(HttpStatusCode::isError, resp ->
+                resp.bodyToMono(String.class)
+                    .flatMap(body -> Mono.error(
+                        new KakaoOAuthException(
+                            "유저 정보 조회 실패: " + resp.statusCode() + " - " + body)
+                    ))
+            )
+            .bodyToMono(KakaoUserResponseDto.class)
+            .block();
+    }
+}

--- a/src/main/java/gift/service/KakaoOAuthService.java
+++ b/src/main/java/gift/service/KakaoOAuthService.java
@@ -14,7 +14,7 @@ import reactor.core.publisher.Mono;
 @Service
 public class KakaoOAuthService {
 
-    @Value("${rest-api.clientId}")
+    @Value("${kakao.clientId}")
     private final String clientId;
 
     @Value("${kakao.auth-url}")
@@ -29,7 +29,7 @@ public class KakaoOAuthService {
     private final WebClient webClient;
 
     public KakaoOAuthService(
-        @Value("${rest-api.clientId}") String clientId,
+        @Value("${kakao.clientId}") String clientId,
         @Value("${kakao.auth-url}") String authUrl,
         @Value("${kakao.api-url}") String apiUrl,
         @Value("${kakao.redirect-uri:}") String redirectUri,

--- a/src/main/java/gift/service/KakaoOAuthService.java
+++ b/src/main/java/gift/service/KakaoOAuthService.java
@@ -3,13 +3,17 @@ package gift.service;
 import gift.dto.api.KakaoTokenResponseDto;
 import gift.dto.api.KakaoUserResponseDto;
 import gift.exception.KakaoOAuthException;
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
 
 @Service
 public class KakaoOAuthService {
@@ -39,7 +43,13 @@ public class KakaoOAuthService {
         this.authUrl    = authUrl;
         this.apiUrl     = apiUrl;
         this.redirectUri= redirectUri;
-        this.webClient = builder.build();
+        this.webClient = builder
+            .clientConnector(new ReactorClientHttpConnector(
+                HttpClient.create()
+                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2_000)
+                    .responseTimeout(Duration.ofSeconds(3))
+            ))
+            .build();
     }
 
     public KakaoTokenResponseDto exchangeCodeForToken(String code) {
@@ -60,6 +70,7 @@ public class KakaoOAuthService {
                     )))
             )
             .bodyToMono(KakaoTokenResponseDto.class)
+            .timeout(Duration.ofSeconds(3))
             .block();
     }
 
@@ -76,6 +87,7 @@ public class KakaoOAuthService {
                     )))
             )
             .bodyToMono(KakaoUserResponseDto.class)
+            .timeout(Duration.ofSeconds(3))
             .block();
     }
 }

--- a/src/main/java/gift/service/KakaoOAuthService.java
+++ b/src/main/java/gift/service/KakaoOAuthService.java
@@ -54,10 +54,10 @@ public class KakaoOAuthService {
             .retrieve()
             .onStatus(HttpStatusCode::isError, resp ->
                 resp.bodyToMono(String.class)
-                    .flatMap(body -> Mono.error(
-                        new KakaoOAuthException(
-                            "토큰 교환 실패: " + resp.statusCode() + " - " + body)
-                    ))
+                    .flatMap(body -> Mono.error(new KakaoOAuthException(
+                        resp.statusCode(),
+                        "토큰 교환 실패: " + resp.statusCode() + " - " + body
+                    )))
             )
             .bodyToMono(KakaoTokenResponseDto.class)
             .block();
@@ -70,10 +70,10 @@ public class KakaoOAuthService {
             .retrieve()
             .onStatus(HttpStatusCode::isError, resp ->
                 resp.bodyToMono(String.class)
-                    .flatMap(body -> Mono.error(
-                        new KakaoOAuthException(
-                            "유저 정보 조회 실패: " + resp.statusCode() + " - " + body)
-                    ))
+                    .flatMap(body -> Mono.error(new KakaoOAuthException(
+                        resp.statusCode(),
+                        "유저 정보 조회 실패: " + resp.statusCode() + " - " + body
+                    )))
             )
             .bodyToMono(KakaoUserResponseDto.class)
             .block();

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -1,5 +1,7 @@
 package gift.service;
 
+import gift.dto.api.KakaoTokenResponseDto;
+import gift.dto.api.KakaoUserResponseDto;
 import gift.dto.api.MemberRegisterRequestDto;
 import gift.entity.Member;
 import gift.exception.InvalidCredentialsException;
@@ -60,13 +62,13 @@ public class MemberService {
     @Transactional
     public String loginWithKakao(String code) {
 
-        var tokenDto = kakaoOAuthService.exchangeCodeForToken(code);
-        var userDto  = kakaoOAuthService.fetchUserInfo(tokenDto.accessToken());
+        KakaoTokenResponseDto tokenDto = kakaoOAuthService.exchangeCodeForToken(code);
+        KakaoUserResponseDto userDto  = kakaoOAuthService.fetchUserInfo(tokenDto.accessToken());
 
         Long kakaoId   = userDto.id();
         String nickname = userDto.nickname();
 
-        var member = memberRepository.findByKakaoId(kakaoId)
+        Member member = memberRepository.findByKakaoId(kakaoId)
             .orElseGet(() ->
                 memberRepository.save(new Member(kakaoId, nickname))
             );

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -59,20 +59,18 @@ public class MemberService {
 
     @Transactional
     public String loginWithKakao(String code) {
-        // 1) 코드 → 토큰, 토큰 → 유저 정보
+
         var tokenDto = kakaoOAuthService.exchangeCodeForToken(code);
         var userDto  = kakaoOAuthService.fetchUserInfo(tokenDto.accessToken());
 
         Long kakaoId   = userDto.id();
         String nickname = userDto.nickname();
 
-        // 2) 카카오 ID로 회원 조회/가입
         var member = memberRepository.findByKakaoId(kakaoId)
             .orElseGet(() ->
                 memberRepository.save(new Member(kakaoId, nickname))
             );
 
-        // 3) JWT 발급 (기존 TokenService 재활용)
         return tokenService.generateToken(member.getId(), nickname);
     }
 }

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -6,17 +6,23 @@ import gift.exception.InvalidCredentialsException;
 import gift.repository.MemberRepository;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberService {
 
     private final MemberRepository memberRepository;
     private final TokenService tokenService;
+    private final KakaoOAuthService kakaoOAuthService;
 
-    public MemberService(MemberRepository memberRepository,
-        TokenService tokenService) {
+    public MemberService(
+        MemberRepository memberRepository,
+        TokenService tokenService,
+        KakaoOAuthService kakaoOAuthService
+    ) {
         this.memberRepository = memberRepository;
         this.tokenService = tokenService;
+        this.kakaoOAuthService = kakaoOAuthService;
     }
 
     // 회원 등록
@@ -49,5 +55,24 @@ public class MemberService {
             .orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
         return member.getIsAdmin();
+    }
+
+    @Transactional
+    public String loginWithKakao(String code) {
+        // 1) 코드 → 토큰, 토큰 → 유저 정보
+        var tokenDto = kakaoOAuthService.exchangeCodeForToken(code);
+        var userDto  = kakaoOAuthService.fetchUserInfo(tokenDto.accessToken());
+
+        Long kakaoId   = userDto.id();
+        String nickname = userDto.nickname();
+
+        // 2) 카카오 ID로 회원 조회/가입
+        var member = memberRepository.findByKakaoId(kakaoId)
+            .orElseGet(() ->
+                memberRepository.save(new Member(kakaoId, nickname))
+            );
+
+        // 3) JWT 발급 (기존 TokenService 재활용)
+        return tokenService.generateToken(member.getId(), nickname);
     }
 }

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -80,9 +80,7 @@ public class OptionService {
         Option option = optionRepository.findById(optionId)
             .orElseThrow(() -> new NoSuchElementException("옵션을 찾을 수 없습니다."));
 
-        // 엔티티 내부에서 검증 & 차감
         option.subtract(qty);
-        // Dirty Checking → 트랜잭션 종료 시 UPDATE
     }
 
     public void deleteOption(Long optionId) {

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -25,7 +25,6 @@ public class ProductService {
     }
 
     public Product registerProduct(Product product) {
-        // '카카오' 문구 검증
         verifyKakaoNameIsApproved(product.getName());
         return repository.save(product);
     }
@@ -39,20 +38,16 @@ public class ProductService {
             .orElseThrow(() -> new NoSuchElementException("상품을 찾을 수 없습니다."));
     }
 
-    // 기존 객체(existing)는 setter가 없는 불변 객체이므로 값을 수정할 수 없음
-    // 따라서 수정된 정보를 반영한 새로운 Product 인스턴스(updated)를 생성하여 업데이트
     public Product updateProduct(long id, ProductUpdateRequestDto updateRequestDto) {
         Product existing = repository.findById(id)
             .orElseThrow(() -> new NoSuchElementException("상품을 찾을 수 없습니다."));
 
-        // 기존 객체와 무관하게 새로운 Product 객체 생성
         Product updated = new Product(id, updateRequestDto.getName(), updateRequestDto.getPrice(),
             updateRequestDto.getImageUrl());
 
-        // '카카오' 문구 검증
         verifyKakaoNameIsApproved(updated.getName());
         repository.save(updated);
-        return updated;  // 또는 existing → 필요에 따라 선택 가능
+        return updated;
     }
 
     public void deleteProduct(Long id) {
@@ -62,7 +57,6 @@ public class ProductService {
         repository.deleteById(id);
     }
 
-    // "카카오" 문구 검증 로직 공통 메서드
     private void verifyKakaoNameIsApproved(String name) {
         if (name.contains("카카오")) {
             if (!approvedRepository.existsByName(name)) {

--- a/src/main/java/gift/service/TokenService.java
+++ b/src/main/java/gift/service/TokenService.java
@@ -35,9 +35,9 @@ public class TokenService {
 
     public Claims parseClaims(String token) {
         return Jwts.parser()
-            .setSigningKey(key)   // 생성 때 사용한 key 그대로
+            .setSigningKey(key)
             .build()
             .parseClaimsJws(token)
-            .getBody();          // exp 검증까지 자동
+            .getBody();
     }
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -60,7 +60,7 @@ public class WishService {
 
         int rows = wishRepository.deleteByMemberIdAndProductId(member.getId(), productId);
 
-        if (rows == 0) {                               // ← 위시 항목 없었음
+        if (rows == 0) {
             throw new NoSuchElementException("위시 목록에 없는 상품입니다.");
         }
     }

--- a/src/main/java/gift/util/BasicAuthHeaderParser.java
+++ b/src/main/java/gift/util/BasicAuthHeaderParser.java
@@ -12,21 +12,17 @@ public class BasicAuthHeaderParser {
 
     public Credentials parse(String authorizationHeader) {
         if (authorizationHeader == null) {
-            // 헤더 누락 → 401 Unauthorized
             throw new MissingAuthorizationHeaderException("Authorization 헤더가 필요합니다.");
         }
         if (!authorizationHeader.startsWith("Basic ")) {
-            // 헤더 형식 오류 → 401 Unauthorized
             throw new InvalidAuthorizationHeaderException("Authorization 헤더 형식이 올바르지 않습니다.");
         }
 
-        // Base64 디코딩
         String base64Cred = authorizationHeader.substring(6).trim();
         byte[] decoded = Base64.getDecoder().decode(base64Cred);
         String cred = new String(decoded, StandardCharsets.UTF_8);
         String[] parts = cred.split(":", 2);
         if (parts.length != 2) {
-            // 디코딩 결과 형식 오류 → 401
             throw new InvalidAuthorizationHeaderException("Authorization 헤더 형식이 올바르지 않습니다.");
         }
 

--- a/src/main/java/gift/util/BearerAuthHeaderParser.java
+++ b/src/main/java/gift/util/BearerAuthHeaderParser.java
@@ -9,11 +9,9 @@ public class BearerAuthHeaderParser {
 
     public String extractBearerToken(String authorizationHeader) {
         if (authorizationHeader == null) {
-            // 헤더 누락 → 401 Unauthorized
             throw new MissingAuthorizationHeaderException("Authorization 헤더가 필요합니다.");
         }
         if (!authorizationHeader.startsWith("Bearer ")) {
-            // 헤더 형식 오류 → 401 Unauthorized
             throw new InvalidAuthorizationHeaderException("Authorization 헤더 형식이 올바르지 않습니다.");
         }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,16 +2,13 @@ spring.config.import=file:.env[.properties]
 
 spring.application.name=spring-gift
 
-# H2 DB 설정
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
-# SQL 스크립트 자동 실행 설정
 spring.sql.init.mode=never
 
-# H2 콘솔 설정
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -6,7 +6,6 @@ CREATE TABLE products
     image_url VARCHAR(255) NOT NULL
 );
 
--- "카카오" 문구가 포함된 상품명을 등록할 수 있는 승인 리스트 테이블
 CREATE TABLE approved_products
 (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -12,5 +12,14 @@
   <button>로그인</button>
 </form>
 
+<a th:href="@{
+  https://kauth.kakao.com/oauth/authorize(
+    client_id=${@environment.getProperty('rest-api.clientId')},
+    redirect_uri='http://localhost:8080',
+    response_type='code',
+    scope='profile_nickname')}">
+  <img src="/img/kakao_login.png" alt="카카오 로그인">
+</a>
+
 <p><a th:href="@{/signup}">계정이 없으신가요? 회원가입</a></p>
 </body></html>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -14,7 +14,7 @@
 
 <a th:href="@{
   https://kauth.kakao.com/oauth/authorize(
-    client_id=${@environment.getProperty('rest-api.clientId')},
+    client_id=${@environment.getProperty('kakao.clientId')},
     redirect_uri='http://localhost:8080',
     response_type='code',
     scope='profile_nickname')}">

--- a/src/main/resources/templates/products/admin/list.html
+++ b/src/main/resources/templates/products/admin/list.html
@@ -50,7 +50,6 @@
   </table>
 
   <nav class="pagination">
-    <!-- Prev -->
     <a class="page-link"
        th:href="${page.first}
              ? null
@@ -59,7 +58,6 @@
       Prev
     </a>
 
-    <!-- 페이지 번호 -->
     <a th:each="i : ${#numbers.sequence(0, page.totalPages - 1)}"
        th:href="@{/admin/products(page=${i},size=${page.size})}"
        th:classappend="${page.number == i} ? 'active'"
@@ -68,7 +66,6 @@
       1
     </a>
 
-    <!-- Next -->
     <a class="page-link"
        th:href="${page.last}
              ? null

--- a/src/main/resources/templates/products/user/list.html
+++ b/src/main/resources/templates/products/user/list.html
@@ -33,7 +33,6 @@
       <td><img th:src="${product.imageUrl}" width="80" /></td>
       <td><a th:href="@{'/products/' + ${product.id}}">상세보기</a></td>
       <td class="actions">
-        <!-- 🆕 Wish 추가 폼 -->
         <form th:action="@{'/wishes/' + ${product.id}}" method="post" style="display:inline">
           <button type="submit">🤍 찜</button>
         </form>
@@ -43,7 +42,6 @@
   </table>
 
   <nav class="pagination">
-    <!-- Prev -->
     <a class="page-link"
        th:href="${page.first}
              ? null
@@ -52,7 +50,6 @@
       Prev
     </a>
 
-    <!-- 페이지 번호 -->
     <a th:each="i : ${#numbers.sequence(0, page.totalPages - 1)}"
        th:href="@{/products(page=${i},size=${page.size})}"
        th:classappend="${page.number == i} ? 'active'"
@@ -61,7 +58,6 @@
       1
     </a>
 
-    <!-- Next -->
     <a class="page-link"
        th:href="${page.last}
              ? null

--- a/src/main/resources/templates/wishes/list.html
+++ b/src/main/resources/templates/wishes/list.html
@@ -35,7 +35,6 @@
 </table>
 
 <nav class="pagination">
-    <!-- Prev -->
     <a class="page-link"
        th:href="${wishPage.first}
              ? null
@@ -44,7 +43,6 @@
         Prev
     </a>
 
-    <!-- 페이지 번호 -->
     <a th:each="i : ${#numbers.sequence(0, wishPage.totalPages - 1)}"
        th:href="@{/wishes(page=${i},size=${wishPage.size})}"
        th:classappend="${wishPage.number == i} ? 'active'"
@@ -53,7 +51,6 @@
         1
     </a>
 
-    <!-- Next -->
     <a class="page-link"
        th:href="${wishPage.last}
              ? null

--- a/src/test/java/gift/AdminProductViewControllerTest.java
+++ b/src/test/java/gift/AdminProductViewControllerTest.java
@@ -74,10 +74,8 @@ public class AdminProductViewControllerTest {
     @DisplayName("[Form] 상품 등록 성공 - '카카오' 포함된 승인된 상품명")
     void createProduct_success_withApprovedName() throws Exception {
 
-        // '카카오' 포함된 승인된 상품명 추가
         approvedProductRepository.save(new ApprovedProduct("카카오 프렌즈 볼펜"));
 
-        // when & then
         mockMvc.perform(post("/admin/products/new")
                 .param("name", "카카오 프렌즈 볼펜")
                 .param("price", "15000")
@@ -130,7 +128,7 @@ public class AdminProductViewControllerTest {
     @DisplayName("[Form] 상품 등록 실패 - 상품명에 허용되지 않은 문자 사용")
     void createProduct_fail_invalidNameCharacters() throws Exception {
         mockMvc.perform(post("/admin/products/new")
-                .param("name", "초콜릿%")      // 허용되지 않은 문자 '%' 사용
+                .param("name", "초콜릿%")
                 .param("price", "1000")
                 .param("imageUrl", "https://image.com/item.jpg")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))
@@ -171,7 +169,7 @@ public class AdminProductViewControllerTest {
         mockMvc.perform(post("/admin/products/new")
                 .param("name", "정상 상품명")
                 .param("price", "1000")
-                .param("imageUrl", "invalid-url") // http/https 아님
+                .param("imageUrl", "invalid-url")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))
             .andExpect(status().isOk())
             .andExpect(view().name("products/admin/form"))
@@ -197,7 +195,6 @@ public class AdminProductViewControllerTest {
         productRepository.save(new Product("초콜릿", 1000, "https://image.com/choco.jpg"));
         productRepository.save(new Product("캔디", 500, "https://image.com/candy.jpg"));
 
-        // 수행 & 검증
         mockMvc.perform(get("/admin/products"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("products/admin/list"))
@@ -304,7 +301,6 @@ public class AdminProductViewControllerTest {
     @Test
     @DisplayName("[Form] 상품 수정 성공 - '카카오' 포함된 승인된 상품명")
     void updateProduct_success_withApprovedName() throws Exception {
-        // '카카오' 포함된 승인된 상품명 추가
         approvedProductRepository.save(new ApprovedProduct("카카오 프렌즈 볼펜"));
 
         Product saved = productRepository.save(
@@ -366,7 +362,7 @@ public class AdminProductViewControllerTest {
         Long id = saved.getId();
 
         mockMvc.perform(post("/admin/products/{id}/edit", id)
-                .param("name", "1234567890123456")      // 16자
+                .param("name", "1234567890123456")
                 .param("price", "1500")
                 .param("imageUrl", "https://image.com/item.jpg")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))
@@ -384,7 +380,7 @@ public class AdminProductViewControllerTest {
         Long id = saved.getId();
 
         mockMvc.perform(post("/admin/products/{id}/edit", id)
-                .param("name", "초콜릿%")      // 허용되지 않은 문자 '%' 사용
+                .param("name", "초콜릿%")
                 .param("price", "1500")
                 .param("imageUrl", "https://image.com/item.jpg")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))

--- a/src/test/java/gift/ApprovedProductRepositoryTest.java
+++ b/src/test/java/gift/ApprovedProductRepositoryTest.java
@@ -18,14 +18,11 @@ public class ApprovedProductRepositoryTest {
     @Test
     @DisplayName("existsByName: 저장된 이름에 대해 true 반환")
     void existsByName_shouldReturnTrue_whenNameExists() {
-        // given
         ApprovedProduct product = new ApprovedProduct("TestProduct");
         approvedProductRepository.save(product);
 
-        // when
         boolean exists = approvedProductRepository.existsByName("TestProduct");
 
-        // then
         assertThat(exists).isTrue();
     }
 

--- a/src/test/java/gift/KakaoOAuthServiceTest.java
+++ b/src/test/java/gift/KakaoOAuthServiceTest.java
@@ -1,0 +1,110 @@
+package gift;
+
+import static org.assertj.core.api.Assertions.*;
+
+import gift.dto.api.KakaoTokenResponseDto;
+import gift.dto.api.KakaoUserResponseDto;
+import gift.exception.KakaoOAuthException;
+import gift.service.KakaoOAuthService;
+import java.io.IOException;
+
+import org.junit.jupiter.api.*;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+class KakaoOAuthServiceTest {
+
+    private MockWebServer server;
+    private KakaoOAuthService service;
+
+    // 테스트용 상수
+    private static final String CLIENT_ID    = "TEST-CLIENT";
+    private static final String REDIRECT_URI = "http://localhost/callback";
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        // WebClient 를 MockWebServer URL로 바꿔서 생성
+        WebClient.Builder builder = WebClient
+            .builder()
+            .baseUrl(server.url("/").toString());;
+
+        // authUrl/apiUrl/redirectUri/clientId/builder 모두 직접 주입
+        service = new KakaoOAuthService(
+            CLIENT_ID,
+            server.url("/oauth").toString(),   // authUrl
+            server.url("/v2/user").toString(), // apiUrl
+            REDIRECT_URI,
+            builder
+        );
+    }
+
+    @AfterEach
+    void shutdown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    void exchangeCodeForToken_success() {
+        // MockWebServer에 토큰 교환 응답 세팅
+        server.enqueue(new MockResponse()
+            .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .setBody("""
+              {
+                "access_token":"AAA",
+                "refresh_token":"RRR",
+                "expires_in":3600,
+                "token_type":"Bearer"
+              }
+            """));
+
+        KakaoTokenResponseDto dto = service.exchangeCodeForToken("CODE123");
+
+        assertThat(dto.accessToken()).isEqualTo("AAA");
+        assertThat(dto.refreshToken()).isEqualTo("RRR");
+        assertThat(dto.expiresIn()).isEqualTo(3600);
+    }
+
+    @Test
+    void fetchUserInfo_success() {
+        // 사용자 정보 조회 응답
+        server.enqueue(new MockResponse()
+            .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .setBody("""
+              {
+                "id":999,
+                "kakao_account":{
+                  "profile":{"nickname":"Neo"}
+                }
+              }
+            """));
+
+        KakaoUserResponseDto user = service.fetchUserInfo("AAA");
+
+        assertThat(user.id()).isEqualTo(999L);
+        assertThat(user.nickname()).isEqualTo("Neo");
+    }
+
+    @Test
+    void exchangeCodeForToken_error() {
+        server.enqueue(new MockResponse().setResponseCode(400).setBody("bad grant"));
+
+        assertThatThrownBy(() -> service.exchangeCodeForToken("BAD"))
+            .isInstanceOf(KakaoOAuthException.class)
+            .hasMessageContaining("토큰 교환 실패");
+    }
+
+    @Test
+    void fetchUserInfo_error() {
+        server.enqueue(new MockResponse().setResponseCode(401).setBody("unauthorized"));
+
+        assertThatThrownBy(() -> service.fetchUserInfo("WRONG"))
+            .isInstanceOf(KakaoOAuthException.class)
+            .hasMessageContaining("유저 정보 조회 실패");
+    }
+}

--- a/src/test/java/gift/KakaoOAuthServiceTest.java
+++ b/src/test/java/gift/KakaoOAuthServiceTest.java
@@ -47,6 +47,7 @@ class KakaoOAuthServiceTest {
     }
 
     @Test
+    @DisplayName("[성공] 인가 코드를 액세스 토큰으로 교환한다")
     void exchangeCodeForToken_success() {
         server.enqueue(new MockResponse()
             .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
@@ -67,6 +68,7 @@ class KakaoOAuthServiceTest {
     }
 
     @Test
+    @DisplayName("[성공] 액세스 토큰으로 카카오 사용자 정보를 가져온다")
     void fetchUserInfo_success() {
         server.enqueue(new MockResponse()
             .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
@@ -86,6 +88,7 @@ class KakaoOAuthServiceTest {
     }
 
     @Test
+    @DisplayName("[실패] 잘못된 인가 코드 → KakaoOAuthException 발생")
     void exchangeCodeForToken_error() {
         server.enqueue(new MockResponse().setResponseCode(400).setBody("bad grant"));
 
@@ -95,6 +98,7 @@ class KakaoOAuthServiceTest {
     }
 
     @Test
+    @DisplayName("[실패] 잘못된 액세스 토큰 → KakaoOAuthException 발생")
     void fetchUserInfo_error() {
         server.enqueue(new MockResponse().setResponseCode(401).setBody("unauthorized"));
 

--- a/src/test/java/gift/KakaoOAuthServiceTest.java
+++ b/src/test/java/gift/KakaoOAuthServiceTest.java
@@ -20,7 +20,6 @@ class KakaoOAuthServiceTest {
     private MockWebServer server;
     private KakaoOAuthService service;
 
-    // 테스트용 상수
     private static final String CLIENT_ID    = "TEST-CLIENT";
     private static final String REDIRECT_URI = "http://localhost/callback";
 
@@ -29,12 +28,10 @@ class KakaoOAuthServiceTest {
         server = new MockWebServer();
         server.start();
 
-        // WebClient 를 MockWebServer URL로 바꿔서 생성
         WebClient.Builder builder = WebClient
             .builder()
             .baseUrl(server.url("/").toString());;
 
-        // authUrl/apiUrl/redirectUri/clientId/builder 모두 직접 주입
         service = new KakaoOAuthService(
             CLIENT_ID,
             server.url("/oauth").toString(),   // authUrl
@@ -51,7 +48,6 @@ class KakaoOAuthServiceTest {
 
     @Test
     void exchangeCodeForToken_success() {
-        // MockWebServer에 토큰 교환 응답 세팅
         server.enqueue(new MockResponse()
             .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
             .setBody("""
@@ -72,7 +68,6 @@ class KakaoOAuthServiceTest {
 
     @Test
     void fetchUserInfo_success() {
-        // 사용자 정보 조회 응답
         server.enqueue(new MockResponse()
             .setHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
             .setBody("""

--- a/src/test/java/gift/MemberControllerTest.java
+++ b/src/test/java/gift/MemberControllerTest.java
@@ -47,7 +47,6 @@ public class MemberControllerTest {
     @Test
     @DisplayName("회원가입 실패 – 이메일 중복 → 409 Conflict + 메시지")
     void register_duplicateEmail() throws Exception {
-        // 먼저 한 번 가입시켜 둠
         MemberRegisterRequestDto req = new MemberRegisterRequestDto("dup@example.com",
             "password123");
 
@@ -56,7 +55,6 @@ public class MemberControllerTest {
                 .content(objectMapper.writeValueAsString(req)))
             .andExpect(status().isCreated());
 
-        // 같은 이메일로 다시 시도
         mockMvc.perform(post("/api/members")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(req)))
@@ -157,7 +155,6 @@ public class MemberControllerTest {
     @Test
     @DisplayName("로그인 실패 – 디코딩 오류/구분자 누락 → 401 Unauthorized + 메시지")
     void login_fail_invalidFormat() throws Exception {
-        // Base64로 인코딩했지만 콜론(:)이 없음
         String bad = Base64.getEncoder()
             .encodeToString("noconstr".getBytes(StandardCharsets.UTF_8));
 

--- a/src/test/java/gift/MemberRepositoryTest.java
+++ b/src/test/java/gift/MemberRepositoryTest.java
@@ -20,15 +20,12 @@ public class MemberRepositoryTest {
     @Test
     @DisplayName("findByEmail & existsByEmail: 저장된 이메일에 대해 조회 및 존재 확인")
     void findByEmail_and_existsByEmail_shouldWork() {
-        // given
         Member m = new Member("user@example.com", "secret");
         memberRepository.save(m);
 
-        // when
         Optional<Member> found = memberRepository.findByEmail("user@example.com");
         boolean exists = memberRepository.existsByEmail("user@example.com");
 
-        // then
         assertThat(found).isPresent();
         assertThat(found.get().getEmail()).isEqualTo("user@example.com");
         assertThat(found.get().getIsAdmin()).isFalse();

--- a/src/test/java/gift/MemberServiceTest.java
+++ b/src/test/java/gift/MemberServiceTest.java
@@ -1,0 +1,102 @@
+package gift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import gift.dto.api.KakaoTokenResponseDto;
+import gift.dto.api.KakaoUserResponseDto;
+import gift.entity.Member;
+import gift.repository.MemberRepository;
+import gift.service.KakaoOAuthService;
+import gift.service.MemberService;
+import gift.service.TokenService;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @MockitoBean
+    private KakaoOAuthService kakaoOAuthService;
+
+    @MockitoBean
+    private TokenService tokenService;
+
+    @Test
+    void loginWithKakao_newMember() {
+        // given
+        String code = "code123";
+        given(kakaoOAuthService.exchangeCodeForToken(code))
+            .willReturn(new KakaoTokenResponseDto("AT","RT",3600,"Bearer"));
+        Map<String,Object> accountMap = Map.of(
+            "profile", Map.of("nickname","Neo")
+        );
+        given(kakaoOAuthService.fetchUserInfo("AT"))
+            .willReturn(new KakaoUserResponseDto(999L, accountMap));
+
+        given(memberRepository.findByKakaoId(anyLong()))
+            .willReturn(Optional.empty());
+        given(memberRepository.save(any(Member.class)))
+            .willAnswer(inv -> inv.getArgument(0));
+
+        given(tokenService.generateToken(any(), anyString()))
+            .willReturn("JWT_TOKEN");
+
+        // when
+        String jwt = memberService.loginWithKakao(code);
+
+        // then
+        assertThat(jwt).isEqualTo("JWT_TOKEN");
+        ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
+        then(memberRepository).should().save(captor.capture());
+        Member saved = captor.getValue();
+        assertThat(saved.getNickname()).isEqualTo("Neo");
+    }
+
+    @Test
+    void loginWithKakao_existingMember() {
+        // given
+        String code = "code456";
+        given(kakaoOAuthService.exchangeCodeForToken(code))
+            .willReturn(new KakaoTokenResponseDto("AT2","RT2",3600,"Bearer"));
+        Map<String,Object> accountMap = Map.of(
+            "profile", Map.of("nickname","Old")
+        );
+        given(kakaoOAuthService.fetchUserInfo("AT2"))
+            .willReturn(new KakaoUserResponseDto(123L, accountMap));
+
+        Member existing = new Member(123L, "Old");
+        given(memberRepository.findByKakaoId(123L))
+            .willReturn(Optional.of(existing));
+
+        given(tokenService.generateToken(any(), anyString()))
+            .willReturn("JWT_OLD");
+
+        // when
+        String jwt = memberService.loginWithKakao(code);
+
+        // then
+        assertThat(jwt).isEqualTo("JWT_OLD");
+        then(memberRepository).should(never()).save(any());
+    }
+}

--- a/src/test/java/gift/MemberServiceTest.java
+++ b/src/test/java/gift/MemberServiceTest.java
@@ -2,7 +2,6 @@ package gift;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -19,28 +18,25 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.transaction.annotation.Transactional;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
+@ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
-    @Autowired
+    @InjectMocks
     private MemberService memberService;
 
-    @MockitoBean
+    @Mock
     private MemberRepository memberRepository;
 
-    @MockitoBean
+    @Mock
     private KakaoOAuthService kakaoOAuthService;
 
-    @MockitoBean
+    @Mock
     private TokenService tokenService;
 
     @Test
@@ -48,15 +44,20 @@ class MemberServiceTest {
     void loginWithKakao_newMember() {
         String code = "code123";
         given(kakaoOAuthService.exchangeCodeForToken(code))
-            .willReturn(new KakaoTokenResponseDto("AT","RT",3600,"Bearer"));
-        Map<String,Object> accountMap = Map.of(
-            "profile", Map.of("nickname","Neo")
+            .willReturn(new KakaoTokenResponseDto(
+                "AT",
+                "RT",
+                3600,
+                "Bearer"
+            ));
+
+        Map<String, Object> accountMap = Map.of(
+            "profile", Map.of("nickname", "Neo")
         );
         given(kakaoOAuthService.fetchUserInfo("AT"))
             .willReturn(new KakaoUserResponseDto(999L, accountMap));
 
-        given(memberRepository.findByKakaoId(anyLong()))
-            .willReturn(Optional.empty());
+        given(memberRepository.findByKakaoId(999L)).willReturn(Optional.empty());
         given(memberRepository.save(any(Member.class)))
             .willAnswer(inv -> inv.getArgument(0));
 
@@ -68,8 +69,7 @@ class MemberServiceTest {
         assertThat(jwt).isEqualTo("JWT_TOKEN");
         ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
         then(memberRepository).should().save(captor.capture());
-        Member saved = captor.getValue();
-        assertThat(saved.getNickname()).isEqualTo("Neo");
+        assertThat(captor.getValue().getNickname()).isEqualTo("Neo");
     }
 
     @Test
@@ -77,16 +77,21 @@ class MemberServiceTest {
     void loginWithKakao_existingMember() {
         String code = "code456";
         given(kakaoOAuthService.exchangeCodeForToken(code))
-            .willReturn(new KakaoTokenResponseDto("AT2","RT2",3600,"Bearer"));
-        Map<String,Object> accountMap = Map.of(
-            "profile", Map.of("nickname","Old")
+            .willReturn(new KakaoTokenResponseDto(
+                "AT2",
+                "RT2",
+                3600,
+                "Bearer"
+            ));
+
+        Map<String, Object> accountMap = Map.of(
+            "profile", Map.of("nickname", "Old")
         );
         given(kakaoOAuthService.fetchUserInfo("AT2"))
             .willReturn(new KakaoUserResponseDto(123L, accountMap));
 
         Member existing = new Member(123L, "Old");
-        given(memberRepository.findByKakaoId(123L))
-            .willReturn(Optional.of(existing));
+        given(memberRepository.findByKakaoId(123L)).willReturn(Optional.of(existing));
 
         given(tokenService.generateToken(any(), anyString()))
             .willReturn("JWT_OLD");

--- a/src/test/java/gift/MemberServiceTest.java
+++ b/src/test/java/gift/MemberServiceTest.java
@@ -17,6 +17,7 @@ import gift.service.MemberService;
 import gift.service.TokenService;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,7 @@ class MemberServiceTest {
     private TokenService tokenService;
 
     @Test
+    @DisplayName("[성공] 신규 카카오 회원 로그인 시 DB에 저장하고 JWT 반환")
     void loginWithKakao_newMember() {
         String code = "code123";
         given(kakaoOAuthService.exchangeCodeForToken(code))
@@ -71,6 +73,7 @@ class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("[성공] 기존 카카오 회원 로그인 시 DB 저장 없이 JWT 반환")
     void loginWithKakao_existingMember() {
         String code = "code456";
         given(kakaoOAuthService.exchangeCodeForToken(code))

--- a/src/test/java/gift/MemberServiceTest.java
+++ b/src/test/java/gift/MemberServiceTest.java
@@ -44,7 +44,6 @@ class MemberServiceTest {
 
     @Test
     void loginWithKakao_newMember() {
-        // given
         String code = "code123";
         given(kakaoOAuthService.exchangeCodeForToken(code))
             .willReturn(new KakaoTokenResponseDto("AT","RT",3600,"Bearer"));
@@ -62,10 +61,8 @@ class MemberServiceTest {
         given(tokenService.generateToken(any(), anyString()))
             .willReturn("JWT_TOKEN");
 
-        // when
         String jwt = memberService.loginWithKakao(code);
 
-        // then
         assertThat(jwt).isEqualTo("JWT_TOKEN");
         ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
         then(memberRepository).should().save(captor.capture());
@@ -75,7 +72,6 @@ class MemberServiceTest {
 
     @Test
     void loginWithKakao_existingMember() {
-        // given
         String code = "code456";
         given(kakaoOAuthService.exchangeCodeForToken(code))
             .willReturn(new KakaoTokenResponseDto("AT2","RT2",3600,"Bearer"));
@@ -92,10 +88,8 @@ class MemberServiceTest {
         given(tokenService.generateToken(any(), anyString()))
             .willReturn("JWT_OLD");
 
-        // when
         String jwt = memberService.loginWithKakao(code);
 
-        // then
         assertThat(jwt).isEqualTo("JWT_OLD");
         then(memberRepository).should(never()).save(any());
     }

--- a/src/test/java/gift/OptionControllerTest.java
+++ b/src/test/java/gift/OptionControllerTest.java
@@ -232,7 +232,6 @@ public class OptionControllerTest {
         @BeforeEach
         void init() {
             option = optionRepository.save(new Option(product, "다크 초콜릿", 10));
-            // duplicate 용
             optionRepository.save(new Option(product, "화이트 초콜릿", 5));
         }
 

--- a/src/test/java/gift/OptionRepositoryTest.java
+++ b/src/test/java/gift/OptionRepositoryTest.java
@@ -57,18 +57,15 @@ public class OptionRepositoryTest {
         boolean expectedPrev,
         boolean expectedNext
     ) {
-        // given ─ 옵션 3개 저장
         optionRepository.saveAll(List.of(
             new Option(product, "다크 초콜릿", 2),
             new Option(product, "화이트 초콜릿", 3),
             new Option(product, "아몬드 초콜릿", 4)
         ));
 
-        // when ─ pageSize=1, id desc
         Pageable pageable = PageRequest.of(pageIndex, 1, Sort.by("id").descending());
         Page<Option> page = optionRepository.findAllByProductId(product.getId(), pageable);
 
-        // then ─ 메타데이터
         assertThat(page.getTotalElements()).isEqualTo(3);
         assertThat(page.getTotalPages()).isEqualTo(3);
         assertThat(page.getNumber()).isEqualTo(pageIndex);
@@ -77,7 +74,6 @@ public class OptionRepositoryTest {
         assertThat(page.hasPrevious()).isEqualTo(expectedPrev);
         assertThat(page.hasNext()).isEqualTo(expectedNext);
 
-        // then ─ 콘텐츠 검증
         assertThat(page.getContent())
             .hasSize(1)
             .extracting(Option::getName, Option::getQuantity)

--- a/src/test/java/gift/ProductControllerTest.java
+++ b/src/test/java/gift/ProductControllerTest.java
@@ -54,7 +54,6 @@ public class ProductControllerTest {
     void createProduct_success_normalName() throws Exception {
         var dto = new ProductCreateRequestDto("초콜릿", 1000, "https://image.com/item.jpg");
 
-        // when & then
         mockMvc.perform(post("/api/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(dto)))
@@ -68,12 +67,10 @@ public class ProductControllerTest {
     @Test
     @DisplayName("[API] 상품 등록 성공 - '카카오' 포함된 승인된 상품명")
     void createProduct_success_withApprovedName() throws Exception {
-        // '카카오' 포함된 승인된 상품명 추가
         approvedProductRepository.save(new ApprovedProduct("카카오 프렌즈 볼펜"));
 
         var dto = new ProductCreateRequestDto("카카오 프렌즈 볼펜", 15000, "https://image.com/item.jpg");
 
-        // when & then
         mockMvc.perform(post("/api/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(dto)))
@@ -89,7 +86,6 @@ public class ProductControllerTest {
     void createProduct_fail_unapprovedKakaoName() throws Exception {
         var dto = new ProductCreateRequestDto("카카오 지갑", 15000, "https://image.com/item.jpg");
 
-        // when & then
         mockMvc.perform(post("/api/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(dto)))
@@ -125,14 +121,12 @@ public class ProductControllerTest {
     @Test
     @DisplayName("[API] 상품 등록 실패 - 상품명에 허용되지 않은 문자 사용")
     void createProduct_fail_invalidNameCharacters() throws Exception {
-        // 준비: 허용되지 않은 특수문자가 포함된 상품명 DTO 생성
         var dto = new ProductCreateRequestDto(
-            "초@콜#릿!",   // 허용되지 않은 문자 포함
+            "초@콜#릿!",
             1000,
             "https://image.com/item.jpg"
         );
 
-        // 수행 & 검증
         mockMvc.perform(post("/api/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(dto)))
@@ -192,14 +186,12 @@ public class ProductControllerTest {
     @Test
     @DisplayName("[API] 상품 등록 실패 - JSON 파싱 오류(400) - 가격에 문자를 넣는 경우")
     void createProduct_fail_invalidJsonFormat() throws Exception {
-        // 1) 잘못된 JSON 바디 직접 작성
         String badJson = "{"
             + "\"name\": \"초콜릿\","
-            + "\"price\": \"과자\","               // 숫자여야 할 필드에 문자열
+            + "\"price\": \"과자\","
             + "\"imageUrl\": \"https://image.com/item.jpg\""
             + "}";
 
-        // 2) perform 요청을 통해 GlobalExceptionHandler.handleHttpMessageNotReadable(...) 동작 검증
         mockMvc.perform(post("/api/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(badJson))
@@ -210,14 +202,12 @@ public class ProductControllerTest {
     @Test
     @DisplayName("[API] 상품 등록 실패 - JSON 파싱 오류(400) - 값 누락")
     void createProduct_fail_missingPrice() throws Exception {
-        // 1) 잘못된 JSON 바디 직접 작성 (price 필드 누락)
         String badJson = "{"
             + "\"name\": \"초콜릿\","
-            + "\"price\": ,"                                // price 값 누락
+            + "\"price\": ,"
             + "\"imageUrl\": \"https://image.com/item.jpg\""
             + "}";
 
-        // 2) perform 요청을 통해 GlobalExceptionHandler.handleHttpMessageNotReadable(...) 동작 검증
         mockMvc.perform(post("/api/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(badJson))
@@ -228,18 +218,14 @@ public class ProductControllerTest {
     @Test
     @DisplayName("[API] 상품 전체 조회 성공 - 200 OK")
     void getAllProducts_success() throws Exception {
-        // 준비: 여러 상품 저장
         productRepository.save(new Product("초콜릿", 1000, "https://image.com/choco.jpg"));
         productRepository.save(new Product("캔디", 500, "https://image.com/candy.jpg"));
 
-        // 수행 & 검증
         mockMvc.perform(get("/api/products")
                         .param("sort", "id,desc")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                // 배열 길이 검증
                 .andExpect(jsonPath("$.content.length()").value(2))
-                // 각 요소 필드 검증
                 .andExpect(jsonPath("$.content[0].name").value("캔디"))
                 .andExpect(jsonPath("$.content[0].price").value(500))
                 .andExpect(jsonPath("$.content[0].imageUrl").value("https://image.com/candy.jpg"))
@@ -251,11 +237,9 @@ public class ProductControllerTest {
     @Test
     @DisplayName("[API] 상품 조회 성공 - 200 OK")
     void getProduct_success() throws Exception {
-        // 준비: 상품 저장
         var saved = productRepository.save(new Product("초콜릿", 1000, "https://image.com/item.jpg"));
         Long id = saved.getId();
 
-        // 수행 & 검증
         mockMvc.perform(get("/api/products/{id}", id)
                 .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -286,18 +270,15 @@ public class ProductControllerTest {
     @Test
     @DisplayName("[API] 상품 수정 성공 - 일반 상품명")
     void updateProduct_success_normalName() throws Exception {
-        // 준비: 기존 상품 저장
         var saved = productRepository.save(
             new Product("초콜릿", 1000, "https://image.com/item.jpg")
         );
         Long id = saved.getId();
 
-        // 수정 DTO
         var dto = new ProductUpdateRequestDto(
             "초콜릿 리미티드", 1200, "https://image.com/new.jpg"
         );
 
-        // 수행 & 검증
         mockMvc.perform(put("/api/products/{id}", id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(dto)))
@@ -311,8 +292,6 @@ public class ProductControllerTest {
     @Test
     @DisplayName("[API] 상품 수정 성공 - '카카오' 포함된 승인된 상품명")
     void updateProduct_success_withApprovedName() throws Exception {
-
-        // '카카오' 포함된 승인된 상품명 추가
         approvedProductRepository.save(new ApprovedProduct("카카오 프렌즈 볼펜"));
 
         var saved = productRepository.save(
@@ -324,7 +303,6 @@ public class ProductControllerTest {
             "카카오 프렌즈 볼펜", 3000, "https://image.com/new.jpg"
         );
 
-        // 수행 & 검증
         mockMvc.perform(put("/api/products/{id}", id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(dto)))
@@ -393,7 +371,7 @@ public class ProductControllerTest {
         Long id = saved.getId();
 
         var dto = new ProductUpdateRequestDto(
-            "",      // 빈 이름
+            "",
             1000,
             "https://image.com/item.jpg"
         );
@@ -414,7 +392,7 @@ public class ProductControllerTest {
         Long id = saved.getId();
 
         var dto = new ProductUpdateRequestDto(
-            "1234567890123456",      // 16자 문자열
+            "1234567890123456",
             1000,
             "https://image.com/item.jpg"
         );
@@ -435,7 +413,7 @@ public class ProductControllerTest {
         Long id = saved.getId();
 
         var dto = new ProductUpdateRequestDto(
-            "초콜릿%",      // 허용되지 않은 문자열 % 사용
+            "초콜릿%",
             1000,
             "https://image.com/item.jpg"
         );
@@ -564,7 +542,7 @@ public class ProductControllerTest {
         String badJson = "{"
             + "\"name\": \"다크 초콜릿\","
             + "\"price\": \"1500\","
-            + "\"imageUrl\": "              // imageUrl 값 누락
+            + "\"imageUrl\": "
             + "}";
 
         mockMvc.perform(put("/api/products/{id}", id)

--- a/src/test/java/gift/ProductRepositoryTest.java
+++ b/src/test/java/gift/ProductRepositoryTest.java
@@ -26,14 +26,11 @@ public class ProductRepositoryTest {
     @Test
     @DisplayName("save & findById: 저장된 상품을 조회할 수 있다")
     void save_and_findById_shouldWork() {
-        // given
         Product p = new Product("Chocolate", 1000, "http://example.com/img.png");
         productRepository.save(p);
 
-        // when
         Product found = productRepository.findById(p.getId()).orElseThrow();
 
-        // then
         assertThat(found.getName()).isEqualTo("Chocolate");
         assertThat(found.getPrice()).isEqualTo(1000);
         assertThat(found.getImageUrl()).isEqualTo("http://example.com/img.png");
@@ -55,7 +52,6 @@ public class ProductRepositoryTest {
         boolean expectedPrev,
         boolean expectedNext
     ) {
-        // given — 기존 데이터 삭제 후 3개 상품 저장
         productRepository.deleteAll();
         productRepository.saveAll(List.of(
                 new Product("A", 1, "http://exampleA.com/img.png"),
@@ -63,22 +59,19 @@ public class ProductRepositoryTest {
                 new Product("C", 3, "http://exampleC.com/img.png")
         ));
 
-        // when — 페이지 크기 1, id 내림차순 정렬
         Pageable pageable = PageRequest.of(
-            pageIndex,                             // page number
-            1,                                        // page size
-            Sort.by("id").descending()      // sort by id desc
+            pageIndex,
+            1,
+            Sort.by("id").descending()
         );
 
         Page<Product> page = productRepository.findAll(pageable);
 
-        // then — 메타데이터 검증 (공통값)
         assertThat(page.getTotalElements()).isEqualTo(3);
         assertThat(page.getTotalPages()).isEqualTo(3);
         assertThat(page.getNumber()).isEqualTo(pageIndex);
         assertThat(page.getSize()).isEqualTo(1);
 
-        // then — 콘텐츠 검증
         assertThat(page.getContent())
             .extracting(Product::getName)
             .containsExactly(expectedName);
@@ -89,7 +82,6 @@ public class ProductRepositoryTest {
             .extracting(Product::getImageUrl)
             .containsExactly(expectedImageUrl);
 
-        // then — 네비게이션 플래그 검증
         assertThat(page.isFirst()).isEqualTo(expectedFirst);
         assertThat(page.hasPrevious()).isEqualTo(expectedPrev);
         assertThat(page.hasNext()).isEqualTo(expectedNext);

--- a/src/test/java/gift/ProductViewControllerTest.java
+++ b/src/test/java/gift/ProductViewControllerTest.java
@@ -44,7 +44,6 @@ public class ProductViewControllerTest {
         productRepository.save(new Product("초콜릿", 1000, "https://image.com/choco.jpg"));
         productRepository.save(new Product("캔디", 500, "https://image.com/candy.jpg"));
 
-        // 수행 & 검증
         mockMvc.perform(get("/admin/products"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("products/admin/list"))

--- a/src/test/java/gift/WishControllerTest.java
+++ b/src/test/java/gift/WishControllerTest.java
@@ -53,18 +53,15 @@ public class WishControllerTest {
     @MockitoBean
     private LoginMemberArgumentResolver loginMemberArgumentResolver;
 
-    Member member; // 매 테스트마다 사용할 로그인 회원
+    Member member;
 
     @BeforeEach
     void setUp() {
-        // (1) 테스트용 회원 저장
         member = memberRepository.save(new Member("test@example.com", "pwd1234"));
 
-        // (2) ArgumentResolver 목 스텁
         given(loginMemberArgumentResolver.supportsParameter(any(MethodParameter.class)))
                 .willAnswer(invocation -> {
                     MethodParameter param = invocation.getArgument(0);
-                    // 오직 @LoginMember가 붙은 Member 파라미터만 true
                     return param.hasParameterAnnotation(LoginMember.class)
                             && Member.class.equals(param.getParameterType());
                 });
@@ -74,28 +71,24 @@ public class WishControllerTest {
                 NativeWebRequest req = invocation.getArgument(2);
                 String header = req.getHeader("Authorization");
                 if (header == null) {
-                    // 헤더 누락 → 401 Unauthorized
                     throw new MissingAuthorizationHeaderException("Authorization 헤더가 필요합니다.");
                 }
                 if (!header.startsWith("Bearer ")) {
-                    // 헤더 형식 오류 → 401 Unauthorized
                     throw new InvalidAuthorizationHeaderException(
                         "Authorization 헤더 형식이 올바르지 않습니다.");
                 }
-                return member; // 항상 로그인 성공
+                return member;
             });
     }
 
     @Test
     @DisplayName("GET /api/wishes – 정상 조회 시 200 OK + JSON 배열 반환")
     void list_withValidAuth_shouldReturnWishItems() throws Exception {
-        // given
         var sampleProduct = new Product("초콜릿", 1000, "https://image.com/choco.png");
         Product saved = productRepository.save(sampleProduct);
         var sampleWishRequestDto = new WishRequestDto(saved.getId(), 2);
         wishService.addWishItemForMember(member, sampleWishRequestDto);
 
-        // when & then
         mockMvc.perform(get("/api/wishes")
                         .header("Authorization", "Bearer dummy-token")  // resolver가 mock이면 토큰 내용 무관
                         .param("page", "0")
@@ -105,7 +98,6 @@ public class WishControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                // 실제 리스트 값 검증
                 .andExpect(jsonPath("$.content", hasSize(1)))
                 .andExpect(jsonPath("$.content[0].productId").value(saved.getId()))
                 .andExpect(jsonPath("$.content[0].name").value("초콜릿"))
@@ -125,10 +117,8 @@ public class WishControllerTest {
                         .accept(MediaType.APPLICATION_JSON)
                 )
                 .andExpect(status().isOk())
-                // 페이징된 결과의 content 배열이 비어 있는지 확인
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.content").isEmpty())
-                // 페이징 메타데이터 검증
                 .andExpect(jsonPath("$.totalElements").value(0))
                 .andExpect(jsonPath("$.totalPages").value(0))
                 .andExpect(jsonPath("$.number").value(0))
@@ -139,13 +129,11 @@ public class WishControllerTest {
     @Test
     @DisplayName("GET /api/wishes – 여러 아이템 조회 (페이징)")
     void list_multipleItems_withPaging_shouldReturnAll() throws Exception {
-        // given
         var p1 = productRepository.save(new Product("초콜릿", 1000, "https://image.com/choco.png"));
         var p2 = productRepository.save(new Product("사탕",   500,  "https://image.com/candy.png"));
         wishService.addWishItemForMember(member, new WishRequestDto(p1.getId(), 1));
         wishService.addWishItemForMember(member, new WishRequestDto(p2.getId(), 3));
 
-        // when & then
         mockMvc.perform(get("/api/wishes")
                         .header("Authorization", "Bearer dummy-token")
                         .param("page", "0")
@@ -155,7 +143,6 @@ public class WishControllerTest {
                 )
                 .andExpect(status().isOk())
 
-                // — 메타데이터 검증 —
                 .andExpect(jsonPath("$.totalElements").value(2))
                 .andExpect(jsonPath("$.totalPages").value(1))
                 .andExpect(jsonPath("$.number").value(0))
@@ -164,7 +151,6 @@ public class WishControllerTest {
                 .andExpect(jsonPath("$.first").value(true))
                 .andExpect(jsonPath("$.last").value(true))
 
-                // — content 리스트 검증 (id 내림차순) —
                 .andExpect(jsonPath("$.content", hasSize(2)))
                 .andExpect(jsonPath("$.content[0].productId").value(p2.getId()))
                 .andExpect(jsonPath("$.content[0].name").value("사탕"))

--- a/src/test/java/gift/WishRepositoryTest.java
+++ b/src/test/java/gift/WishRepositoryTest.java
@@ -34,17 +34,14 @@ public class WishRepositoryTest {
     @Test
     @DisplayName("findAllByMemberId: 해당 회원의 찜 목록 조회")
     void findAllByMemberId_shouldReturnItems_forMember() {
-        // given
         Member m = memberRepository.save(new Member("u1@example.com", "password"));
         Product p = productRepository.save(new Product("P1", 1000, "http://example.com/img.png"));
         WishItem wi = new WishItem(m, p, 3);
         wishRepository.save(wi);
 
-        // when — 페이지 크기 5, id 내림차순, 0번 페이지 조회
         Pageable pageable = PageRequest.of(0, 5, Sort.by("id").descending());
         Page<WishItem> page = wishRepository.findAllByMemberId(m.getId(), pageable);
 
-        // then — 페이징 메타데이터 검증
         assertThat(page.getTotalElements()).isEqualTo(1);    // 전체 아이템 수
         assertThat(page.getTotalPages()).isEqualTo(1);       // 전체 페이지 수
         assertThat(page.getNumber()).isZero();                       // 현재 페이지 인덱스
@@ -52,7 +49,6 @@ public class WishRepositoryTest {
         assertThat(page.isFirst()).isTrue();
         assertThat(page.isLast()).isTrue();
 
-        // then — 콘텐츠 검증
         List<WishItem> content = page.getContent();
         assertThat(content).hasSize(1);
 
@@ -66,16 +62,13 @@ public class WishRepositoryTest {
     @Test
     @DisplayName("deleteByMemberIdAndProductId: 해당 항목 삭제 후 영향 개수 반환")
     void deleteByMemberIdAndProductId_shouldDeleteAndReturnCount() {
-        // given
         Member m = memberRepository.save(new Member("u2@example.com", "password"));
         Product p = productRepository.save(new Product("P2", 2000, "http://example.com/img.png"));
         WishItem wi = new WishItem(m, p, 5);
         wishRepository.save(wi);
 
-        // when
         int deleted = wishRepository.deleteByMemberIdAndProductId(m.getId(), p.getId());
 
-        // then
         assertThat(deleted).isEqualTo(1);
         assertThat(wishRepository.findAllByMemberId(m.getId())).isEmpty();
     }

--- a/src/test/java/gift/WishViewControllerTest.java
+++ b/src/test/java/gift/WishViewControllerTest.java
@@ -56,18 +56,15 @@ public class WishViewControllerTest {
     @MockitoBean
     private LoginMemberArgumentResolver loginMemberArgumentResolver;
 
-    Member member;        // 매 테스트에서 사용할 로그인 회원
+    Member member;
 
     @BeforeEach
     void setUp() {
-        // (1) 테스트용 회원 저장
         member = memberRepository.save(new Member("test@example.com", "pwd1234"));
 
-        // (2) ArgumentResolver 목 스텁
         given(loginMemberArgumentResolver.supportsParameter(any(MethodParameter.class)))
                 .willAnswer(invocation -> {
                     MethodParameter param = invocation.getArgument(0);
-                    // 오직 @LoginMember가 붙은 Member 파라미터만 true
                     return param.hasParameterAnnotation(LoginMember.class)
                             && Member.class.equals(param.getParameterType());
                 });
@@ -77,26 +74,22 @@ public class WishViewControllerTest {
                 NativeWebRequest req = invocation.getArgument(2);
                 String header = req.getHeader("Authorization");
                 if (header == null) {
-                    // 헤더 누락 → 401 Unauthorized
                     throw new MissingAuthorizationHeaderException("Authorization 헤더가 필요합니다.");
                 }
                 if (!header.startsWith("Bearer ")) {
-                    // 헤더 형식 오류 → 401 Unauthorized
                     throw new InvalidAuthorizationHeaderException(
                         "Authorization 헤더 형식이 올바르지 않습니다.");
                 }
-                return member; // 항상 로그인 성공
+                return member;
             });
     }
 
     @Test
     @DisplayName("POST /wishes/{id} – 정상 추가 ⇒ Found")
     void addWish_success_redirect() throws Exception {
-        // given 상품 1개 저장
         Product saved = productRepository.save(
             new Product("초콜릿", 1000, "https://image.com/choco.png"));
 
-        // when & then
         mockMvc.perform(post("/wishes/{id}", saved.getId())
                 .header("Authorization", "Bearer dummy-token"))
             .andExpect(status().isFound())
@@ -163,19 +156,16 @@ public class WishViewControllerTest {
                                 hasProperty("name", is("초콜릿"))
                         ))
                 ))
-                // price
                 .andExpect(model().attribute("wishPage",
                         hasProperty("content", contains(
                                 hasProperty("price", is(1000))
                         ))
                 ))
-                // imageUrl
                 .andExpect(model().attribute("wishPage",
                         hasProperty("content", contains(
                                 hasProperty("imageUrl", is("https://image.com/choco.png"))
                         ))
                 ))
-                // quantity
                 .andExpect(model().attribute("wishPage",
                         hasProperty("content", contains(
                                 hasProperty("quantity", is(1))
@@ -215,21 +205,18 @@ public class WishViewControllerTest {
                                 hasProperty("name", is("초콜릿"))
                         ))
                 ))
-                // price
                 .andExpect(model().attribute("wishPage",
                         hasProperty("content", contains(
                                 hasProperty("price", is(500)),
                                 hasProperty("price", is(1000))
                         ))
                 ))
-                // imageUrl
                 .andExpect(model().attribute("wishPage",
                         hasProperty("content", contains(
                                 hasProperty("imageUrl", is("https://image.com/candy.png")),
                                 hasProperty("imageUrl", is("https://image.com/choco.png"))
                         ))
                 ))
-                // quantity
                 .andExpect(model().attribute("wishPage",
                         hasProperty("content", contains(
                                 hasProperty("quantity", is(2)),
@@ -279,7 +266,6 @@ public class WishViewControllerTest {
         Product p = productRepository.save(
             new Product("젤리", 700, "https://image.com/jelly.png"));
 
-        // wishRepository 에는 넣지 않아 존재하지 않는 상태
         mockMvc.perform(post("/wishes/{productId}/delete", p.getId())
                 .header("Authorization", "Bearer dummy"))
             .andExpect(status().isNotFound())


### PR DESCRIPTION
## 구현 내용 요약

- [feat] Kakao OAuth 로그인 기능 추가

  - AuthViewController에 카카오 인가 콜백 엔드포인트 구현

    - 인가 코드 → 액세스 토큰 요청 → 사용자 정보 조회 → JWT 발급 → HttpOnly 쿠키 설정 → 리다이렉트

  - KakaoTokenResponseDto, KakaoUserResponseDto DTO 정의

  - KakaoOAuthService 구현 및 예외 처리용 KakaoOAuthException 추가

  - Member 엔티티에 kakaoId, nickname 필드 추가 및 관련 생성자/Getter 반영

  - MemberRepository에 findByKakaoId 메서드 추가

  - MemberService.loginWithKakao() 로직 구현

  - 로그인 페이지(login.html)에 카카오 로그인 버튼 블록 삽입

  - 단위 테스트 작성

    - KakaoOAuthServiceTest

    - MemberServiceTest

  - build.gradle에 spring-boot-starter-webflux, okhttp3-mockwebserver 의존성 추가

---

## 테스트 및 검증

- `KakaoOAuthServiceTest`, `MemberServiceTest` 단위 테스트 구현

---

## 카카오 앱 설정

<img width="1250" height="423" alt="image" src="https://github.com/user-attachments/assets/bad54259-0770-4fa5-8e8e-753ef1d4cba7" />

<img width="1261" height="765" alt="image" src="https://github.com/user-attachments/assets/e2be8d65-f4b3-453e-adfe-6b111a32c3ab" />

<img width="1209" height="511" alt="image" src="https://github.com/user-attachments/assets/f67afb6a-e686-4a92-89ae-ad5ea375a317" />

<img width="1200" height="373" alt="image" src="https://github.com/user-attachments/assets/a0076600-71d7-488e-8426-ae2fd1f92e61" />

<img width="1196" height="667" alt="image" src="https://github.com/user-attachments/assets/a99de9f9-98d1-4ddb-9896-a7d7b060069f" />

<img width="1198" height="503" alt="image" src="https://github.com/user-attachments/assets/d7f84d08-6a78-4388-a594-5e4afe748138" />

---

## 실제 UI 화면

<img width="236" height="269" alt="image" src="https://github.com/user-attachments/assets/313f3794-3c2e-48c3-a8d1-c4f5e8d42c5b" />

<img width="656" height="781" alt="image" src="https://github.com/user-attachments/assets/7f72a59c-c8d9-4130-ac84-623a25b0f5d9" />

<img width="523" height="742" alt="image" src="https://github.com/user-attachments/assets/bf2567e3-d137-479f-8fb3-c3f75a842cb6" />

<img width="1920" height="871" alt="image" src="https://github.com/user-attachments/assets/b11ba58f-398a-4499-b844-fe9b5aa4f563" />

<img width="807" height="419" alt="image" src="https://github.com/user-attachments/assets/74063c83-9056-455d-acc5-21d6c67d094b" />

정상적으로 member 테이블에 카카오로 로그인한 회원의 데이터가 담기게 됩니다.

---

## 추가 설명

### **`WebClient` 를 선택한 이유**

- RestClient 의 종류와 특징

1. RestClient

  - RestTemplate 뒤를 잇는 동기 방식의 새로운 클라이언트
  - Java 11+ HttpClient ( JDK 기본 API ) 위에 플루언트 API를 씌운 형태
  - `RestClient.builder()` → 인터페이스로 타입 세이프 하게 호출 정의 가능
  - RestClient 는 WebClient 만큼 무겁지 않으면서도, RestTemplate 보다 모던한 API, WebClient 보다 단순한 구조
  - 장점: 동기이면서도 모던한 JDK HTTP 클라이언트 활용, 가볍고 직관적
  - 단점: 아직 생소하고, 레거시 RestTemplate 와 완벽 호환은 아님

2. WebClient

  - 비동기 ( reactive ), 논블로킹 ( non‑blocking ) 방식의 플루언트 API
  - Reactor 기반으로 만들어져, Flux/Mono 형태로 응답을 처리
  - 스케일 아웃 ( scale‑out ) 구조나 고성능 I/O 환경에 적합
  - `WebClient.builder()` 로 공통 설정 ( baseUrl, default header, 필터 등 ) 을 한 번만 정의하고 재사용
  - 장점: 반응형 파이프라인, back‑pressure, 커넥션 풀링 내장, 기능 확장성 ↑
  - 단점: 사용법이 다소 복잡, 간단한 동기 호출엔 오버헤드

3. RestTemplate

  - 동기 ( synchronous ) 방식의 템플릿 API
  - `getForObject()`, `postForEntity()` 같은 메서드 호출 위주
  - 내부에서 HTTP 요청이 끝날 때까지 스레드를 블로킹
  - Spring 3.0 부터 쓰이던 전통적 방식으로, 간단한 동기 호출에 여전히 널리 사용
  - 장점: 배우기 쉽고, 코드도 직관적
  - 단점: Reactive 흐름과 잘 어울리지 않으며, 성능 튜닝 ( 커넥션 풀 등 ) 을 직접 해 줘야 함

4. HTTP Interface

  - 인터페이스 선언만으로 REST 호출 메서드를 정의
  - 어노테이션 ( `@GetExchange`, `@PostExchange` 등 ) 을 붙이면 스프링이 런타임에 프록시 구현체를 자동 생성
  - 코드가 가장 간결해지고, HTTP 호출을 타입 세이프하게 처리
  - 장점: 서비스 계층 코드가 깔끔해지고, API 스펙 문서처럼 바로 읽을 수 있음
  - 단점: 아직 실험적 ( 6.1 기준 ), 커스터마이징이 제한적일 수 있음

---

- **WebClient 를 선택한 이유**

  - 비동기/블로킹 둘 다 OK
    - 토큰 교환·유저 조회는 I/O 가 묶이기 쉬운 작업인데, non‑blocking 으로 처리하고 필요할 땐 `.block()` 으로 동기처럼 쓸 수 있음
  - 공통 설정 재사용성
    - `.mutate()` 나 `WebClient.builder()` 를 통해 baseUrl, default header, 응답/요청 필터 등을 한 곳에 모아 두기 편함
  - 커넥션 풀, 타임아웃, 리트라이 같은 고급 설정이 내장되어 있어, 운영 환경에서 안정적으로 쓸 수 있음
  - 생태계 호환성
    - Spring Security, Spring Cloud Gateway 등 리액티브 스택과도 자연스럽게 맞물림

성능·안정성 ( 논블로킹 I/O, 커넥션 관리 ), 유지보수성 ( 재사용 설정, 필터 AOP ), 확장성 ( 전면 리액티브 전환이나 다중 엔드포인트 연동 ) 측면에서 **`WebClient`** 가 가장 적절하다고 생각했습니다.

---

리뷰 부탁드립니다!