### PR TITLE
충남대 BE_좌진우 1단계 - 카카오 로그인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Mac OS ###
 .DS_Store
+
+### secrets.properties ignore
+/src/main/resources/secrets.properties

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## 목차
 
 0. [0단계 - 기본 코드 준비](#step-0---기본-코드-준비)
+1. [1단계 - 카카오 로그인](#step-1---카카오-로그인)
 
 ---
 
@@ -16,4 +17,53 @@
 
 #### 기능 요구 사항
 
-- `상품 고도화` 코드를 옮기기 
+- `상품 고도화` 코드를 옮기기
+
+---
+
+<br>
+
+## Step 1 - 카카오 로그인
+
+---
+
+#### 기능 요구 사항
+
+- 카카오 로그인을 통해 인가 코드를 받고, 인가 코드를 통해 토큰을 받는다
+  + 카카오 계정 로그인을 통해 인가 코드를 받음
+  + 인가 코드로 액세스 토큰을 요청
+  + 토큰을 수신
+
+<br>
+
+#### 세부 구현 사항
+
+- `/auth/kakao/login`에서 카카오 인가 요청 URL로 302 리다이렉트
+  + `client_id`, `redirect_uri`, `response_type=code`를 포함한 URL을 생성
+  + 사용자가 카카오 로그인, 동의 과정을 완료시 인가 코드 발급
+
+<br>
+
+- `/auth/kakao/callback`에서 인가 코드를 수신
+  + 쿼리 파라미터로 전달된 code 값을 추출
+
+<br>
+
+- 인가 코드로 카카오 토큰 API에 POST 요청
+  + `grant_type=authorization_code`, `client_id`, `redirect_uri`, `code` 포함
+
+<br>
+
+- 카카오로부터 액세스 토큰, 리프레시 토큰 등의 정보를 포함한 JSON 응답 수신
+  + 응답을 `KakaoTokenResponseDto` 객체로 매핑
+  + `ResponseEntity`를 통해 응답 상태 코드와 함께 반환
+
+<br>
+
+- Spring Boot의 `RestClient`를 사용해 외부 API 통신 구현
+
+<br>
+
+- 인가 요청과 토큰 요청에 필요한 설정 값을 `application.properties`에서 관리
+
+

--- a/src/main/java/gift/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/gift/auth/client/KakaoOAuthClient.java
@@ -1,0 +1,58 @@
+package gift.auth.client;
+
+import gift.auth.config.KakaoOauthProperties;
+import gift.auth.dto.KakaoTokenResponseDto;
+import gift.auth.dto.KakaoUserInfoResponseDto;
+import gift.common.exception.KakaoOAuthClientException;
+import gift.common.exception.KakaoOAuthServerException;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class KakaoOAuthClient {
+
+    private final RestClient restClient = RestClient.create();
+    private final KakaoOauthProperties kakaoProps;
+
+    public KakaoOAuthClient(KakaoOauthProperties kakaoProps) {
+        this.kakaoProps = kakaoProps;
+    }
+
+    public String getAuthorizeUrl() {
+        return kakaoProps.getAuthorizeUrl();
+    }
+
+    public KakaoTokenResponseDto requestToken(String code) {
+        String body = kakaoProps.getTokenRequestBody(code);
+
+        return restClient.post()
+                .uri(kakaoProps.tokenUrl())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                    throw new KakaoOAuthClientException(response.getStatusCode().value(), response.getBody().toString());
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    throw new KakaoOAuthServerException(response.getStatusCode().value(), response.getBody().toString());
+                })
+                .body(KakaoTokenResponseDto.class);
+    }
+
+    public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
+        return restClient.get()
+                .uri(kakaoProps.userInfoUrl())
+                .header("Authorization", "Bearer " + accessToken)
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                    throw new KakaoOAuthClientException(res.getStatusCode().value(), res.getBody().toString());
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                    throw new KakaoOAuthServerException(res.getStatusCode().value(), res.getBody().toString());
+                })
+                .body(KakaoUserInfoResponseDto.class);
+    }
+}

--- a/src/main/java/gift/auth/config/KakaoOauthProperties.java
+++ b/src/main/java/gift/auth/config/KakaoOauthProperties.java
@@ -1,0 +1,25 @@
+package gift.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakao")
+public record KakaoOauthProperties(
+        String clientId,
+        String redirectUri,
+        String authUrl,
+        String tokenUrl
+) {
+    public String getAuthorizeUrl() {
+        return authUrl +
+                "?response_type=code" +
+                "&client_id=" + clientId +
+                "&redirect_uri=" + redirectUri;
+    }
+
+    public String getTokenRequestBody(String code) {
+        return "grant_type=authorization_code" +
+                "&client_id=" + clientId +
+                "&redirect_uri=" + redirectUri +
+                "&code=" + code;
+    }
+}

--- a/src/main/java/gift/auth/config/KakaoOauthProperties.java
+++ b/src/main/java/gift/auth/config/KakaoOauthProperties.java
@@ -7,7 +7,8 @@ public record KakaoOauthProperties(
         String clientId,
         String redirectUri,
         String authUrl,
-        String tokenUrl
+        String tokenUrl,
+        String userInfoUrl
 ) {
     public String getAuthorizeUrl() {
         return authUrl +

--- a/src/main/java/gift/auth/controller/KakaoAuthController.java
+++ b/src/main/java/gift/auth/controller/KakaoAuthController.java
@@ -1,18 +1,14 @@
 package gift.auth.controller;
 
-import gift.auth.config.KakaoOauthProperties;
-import gift.auth.dto.KakaoTokenResponseDto;
-import gift.common.exception.KakaoOAuthClientException;
-import gift.common.exception.KakaoOAuthServerException;
+import gift.auth.service.KakaoAuthService;
+import gift.member.dto.MemberResponseDto;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestClient;
 
 import java.io.IOException;
 
@@ -20,39 +16,20 @@ import java.io.IOException;
 @RequestMapping("auth/kakao")
 public class KakaoAuthController {
 
-    private final RestClient restClient = RestClient.create();
-    private final KakaoOauthProperties kakaoProps;
+    private final KakaoAuthService kakaoAuthService;
 
-    public KakaoAuthController(KakaoOauthProperties kakaoProps) {
-        this.kakaoProps = kakaoProps;
+    public KakaoAuthController(KakaoAuthService kakaoAuthService) {
+        this.kakaoAuthService = kakaoAuthService;
     }
 
     @GetMapping("/login")
     public void redirectToKakaoAuth(HttpServletResponse response) throws IOException {
-        response.sendRedirect(kakaoProps.getAuthorizeUrl());
+        response.sendRedirect(kakaoAuthService.getKakaoAuthorizeUrl());
     }
 
     @GetMapping("/callback")
-    public ResponseEntity<KakaoTokenResponseDto> kakaoCallback(@RequestParam("code") String code) {
-        String body = kakaoProps.getTokenRequestBody(code);
-
-        ResponseEntity<KakaoTokenResponseDto> res = restClient.post()
-                .uri("https://kauth.kakao.com/oauth/token")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(body)
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, ((request, response) -> {
-                    throw new KakaoOAuthClientException(response.getStatusCode().value(), response.getBody().toString());
-                }))
-                .onStatus(HttpStatusCode::is5xxServerError, ((request, response) -> {
-                    throw new KakaoOAuthServerException(response.getStatusCode().value(), response.getBody().toString());
-                }))
-                .toEntity(KakaoTokenResponseDto.class);
-
-        return ResponseEntity
-                .status(res.getStatusCode())
-                .body(res.getBody());
+    public ResponseEntity<MemberResponseDto> kakaoCallback(@RequestParam("code") String code) {
+        MemberResponseDto memberDto = kakaoAuthService.loginWithKakao(code);
+        return ResponseEntity.status(HttpStatus.OK).body(memberDto);
     }
-
-
 }

--- a/src/main/java/gift/auth/controller/KakaoAuthController.java
+++ b/src/main/java/gift/auth/controller/KakaoAuthController.java
@@ -2,7 +2,10 @@ package gift.auth.controller;
 
 import gift.auth.config.KakaoOauthProperties;
 import gift.auth.dto.KakaoTokenResponseDto;
+import gift.common.exception.KakaoOAuthClientException;
+import gift.common.exception.KakaoOAuthServerException;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,16 +36,22 @@ public class KakaoAuthController {
     public ResponseEntity<KakaoTokenResponseDto> kakaoCallback(@RequestParam("code") String code) {
         String body = kakaoProps.getTokenRequestBody(code);
 
-        ResponseEntity<KakaoTokenResponseDto> response = restClient.post()
+        ResponseEntity<KakaoTokenResponseDto> res = restClient.post()
                 .uri("https://kauth.kakao.com/oauth/token")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(body)
                 .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, ((request, response) -> {
+                    throw new KakaoOAuthClientException(response.getStatusCode().value(), response.getBody().toString());
+                }))
+                .onStatus(HttpStatusCode::is5xxServerError, ((request, response) -> {
+                    throw new KakaoOAuthServerException(response.getStatusCode().value(), response.getBody().toString());
+                }))
                 .toEntity(KakaoTokenResponseDto.class);
 
         return ResponseEntity
-                .status(response.getStatusCode())
-                .body(response.getBody());
+                .status(res.getStatusCode())
+                .body(res.getBody());
     }
 
 

--- a/src/main/java/gift/auth/controller/KakaoAuthController.java
+++ b/src/main/java/gift/auth/controller/KakaoAuthController.java
@@ -1,8 +1,8 @@
 package gift.auth.controller;
 
+import gift.auth.config.KakaoOauthProperties;
 import gift.auth.dto.KakaoTokenResponseDto;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,29 +18,20 @@ import java.io.IOException;
 public class KakaoAuthController {
 
     private final RestClient restClient = RestClient.create();
+    private final KakaoOauthProperties kakaoProps;
 
-    @Value("${kakao.client-id}")
-    private String clientId;
-
-    @Value("${kakao.redirect-uri}")
-    private String redirectUri;
+    public KakaoAuthController(KakaoOauthProperties kakaoProps) {
+        this.kakaoProps = kakaoProps;
+    }
 
     @GetMapping("/login")
     public void redirectToKakaoAuth(HttpServletResponse response) throws IOException {
-        String kakaoAuthUrl = "https://kauth.kakao.com/oauth/authorize" +
-                "?response_type=code" +
-                "&client_id=" + clientId +
-                "&redirect_uri=" + redirectUri;
-
-        response.sendRedirect(kakaoAuthUrl);
+        response.sendRedirect(kakaoProps.getAuthorizeUrl());
     }
 
     @GetMapping("/callback")
     public ResponseEntity<KakaoTokenResponseDto> kakaoCallback(@RequestParam("code") String code) {
-        String body = "grant_type=authorization_code" +
-                "&client_id=" + clientId +
-                "&redirect_uri=" + redirectUri +
-                "&code=" + code;
+        String body = kakaoProps.getTokenRequestBody(code);
 
         ResponseEntity<KakaoTokenResponseDto> response = restClient.post()
                 .uri("https://kauth.kakao.com/oauth/token")

--- a/src/main/java/gift/auth/controller/KakaoAuthController.java
+++ b/src/main/java/gift/auth/controller/KakaoAuthController.java
@@ -1,0 +1,58 @@
+package gift.auth.controller;
+
+import gift.auth.dto.KakaoTokenResponseDto;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("auth/kakao")
+public class KakaoAuthController {
+
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @GetMapping("/login")
+    public void redirectToKakaoAuth(HttpServletResponse response) throws IOException {
+        String kakaoAuthUrl = "https://kauth.kakao.com/oauth/authorize" +
+                "?response_type=code" +
+                "&client_id=" + clientId +
+                "&redirect_uri=" + redirectUri;
+
+        response.sendRedirect(kakaoAuthUrl);
+    }
+
+    @GetMapping("/callback")
+    public ResponseEntity<KakaoTokenResponseDto> kakaoCallback(@RequestParam("code") String code) {
+        String body = "grant_type=authorization_code" +
+                "&client_id=" + clientId +
+                "&redirect_uri=" + redirectUri +
+                "&code=" + code;
+
+        ResponseEntity<KakaoTokenResponseDto> response = restClient.post()
+                .uri("https://kauth.kakao.com/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .toEntity(KakaoTokenResponseDto.class);
+
+        return ResponseEntity
+                .status(response.getStatusCode())
+                .body(response.getBody());
+    }
+
+
+}

--- a/src/main/java/gift/auth/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/gift/auth/dto/KakaoTokenResponseDto.java
@@ -1,0 +1,9 @@
+package gift.auth.dto;
+
+public record KakaoTokenResponseDto(
+        String token_type,
+        String access_token,
+        String refresh_token,
+        Integer expires_in,
+        Integer refresh_token_expires_in
+) { }

--- a/src/main/java/gift/auth/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/gift/auth/dto/KakaoTokenResponseDto.java
@@ -1,9 +1,9 @@
 package gift.auth.dto;
 
 public record KakaoTokenResponseDto(
-        String token_type,
-        String access_token,
-        String refresh_token,
-        Integer expires_in,
-        Integer refresh_token_expires_in
+        String tokenType,
+        String accessToken,
+        String refreshToken,
+        Integer expiresId,
+        Integer refreshTokenExpiresIn
 ) { }

--- a/src/main/java/gift/auth/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/gift/auth/dto/KakaoTokenResponseDto.java
@@ -1,9 +1,20 @@
 package gift.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record KakaoTokenResponseDto(
+        @JsonProperty("token_type")
         String tokenType,
+
+        @JsonProperty("access_token")
         String accessToken,
+
+        @JsonProperty("refresh_token")
         String refreshToken,
-        Integer expiresId,
+
+        @JsonProperty("expires_in")
+        Integer expiresIn,
+
+        @JsonProperty("refresh_token_expires_in")
         Integer refreshTokenExpiresIn
 ) { }

--- a/src/main/java/gift/auth/dto/KakaoUserInfoResponseDto.java
+++ b/src/main/java/gift/auth/dto/KakaoUserInfoResponseDto.java
@@ -1,0 +1,13 @@
+package gift.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfoResponseDto(
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    public String getEmail() {
+        return kakaoAccount != null ? kakaoAccount.email() : null;
+    }
+
+    public record KakaoAccount(@JsonProperty("email") String email) {}
+}

--- a/src/main/java/gift/auth/service/DefaultKakaoAuthService.java
+++ b/src/main/java/gift/auth/service/DefaultKakaoAuthService.java
@@ -1,0 +1,44 @@
+package gift.auth.service;
+
+import gift.auth.client.KakaoOAuthClient;
+import gift.auth.dto.KakaoTokenResponseDto;
+import gift.auth.dto.KakaoUserInfoResponseDto;
+import gift.member.dto.MemberResponseDto;
+import gift.member.entity.Member;
+import gift.member.entity.Role;
+import gift.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DefaultKakaoAuthService implements KakaoAuthService {
+
+    private final MemberRepository memberRepository;
+    private final KakaoOAuthClient kakaoOAuthClient;
+
+    public DefaultKakaoAuthService(MemberRepository memberRepository,  KakaoOAuthClient kakaoOAuthClient) {
+        this.memberRepository = memberRepository;
+        this.kakaoOAuthClient = kakaoOAuthClient;
+    }
+
+    public String getKakaoAuthorizeUrl() {
+        return kakaoOAuthClient.getAuthorizeUrl();
+    }
+
+    @Override
+    @Transactional
+    public MemberResponseDto loginWithKakao(String code) {
+
+        KakaoTokenResponseDto tokenResponse = kakaoOAuthClient.requestToken(code);
+
+        KakaoUserInfoResponseDto userInfo = kakaoOAuthClient.getUserInfo(tokenResponse.accessToken());
+
+        Member member = memberRepository.findByEmail(userInfo.getEmail())
+                .orElseGet(() -> {
+                    Member newMember = new Member(userInfo.getEmail(), "password111", Role.USER);
+                    return memberRepository.save(newMember);
+                });
+
+        return new MemberResponseDto(member);
+    }
+}

--- a/src/main/java/gift/auth/service/KakaoAuthService.java
+++ b/src/main/java/gift/auth/service/KakaoAuthService.java
@@ -1,0 +1,9 @@
+package gift.auth.service;
+
+import gift.member.dto.MemberResponseDto;
+
+public interface KakaoAuthService {
+    MemberResponseDto loginWithKakao(String code);
+
+    String getKakaoAuthorizeUrl();
+}

--- a/src/main/java/gift/common/config/KakaoPropertiesConfig.java
+++ b/src/main/java/gift/common/config/KakaoPropertiesConfig.java
@@ -1,0 +1,10 @@
+package gift.common.config;
+
+import gift.auth.config.KakaoOauthProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(KakaoOauthProperties.class)
+public class KakaoPropertiesConfig {
+}

--- a/src/main/java/gift/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/common/exception/GlobalExceptionHandler.java
@@ -56,4 +56,16 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleProductOptionRequired(ProductOptionRequiredException ex) {
         return new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
     }
+
+    @ExceptionHandler(KakaoOAuthClientException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleKakaoOAuthClientException(KakaoOAuthClientException ex) {
+        return new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+    }
+
+    @ExceptionHandler(KakaoOAuthServerException.class)
+    @ResponseStatus(HttpStatus.BAD_GATEWAY)
+    public ErrorResponse handleKakaoOAuthServerException(KakaoOAuthServerException ex) {
+        return new ErrorResponse(HttpStatus.BAD_GATEWAY.value(), ex.getMessage());
+    }
 }

--- a/src/main/java/gift/common/exception/KakaoOAuthClientException.java
+++ b/src/main/java/gift/common/exception/KakaoOAuthClientException.java
@@ -1,0 +1,7 @@
+package gift.common.exception;
+
+public class KakaoOAuthClientException extends RuntimeException {
+    public KakaoOAuthClientException(int statusCode, String responseBody) {
+      super("클라이언트 오류 (status=" + statusCode + "): " + responseBody);
+    }
+}

--- a/src/main/java/gift/common/exception/KakaoOAuthServerException.java
+++ b/src/main/java/gift/common/exception/KakaoOAuthServerException.java
@@ -1,0 +1,7 @@
+package gift.common.exception;
+
+public class KakaoOAuthServerException extends RuntimeException {
+    public KakaoOAuthServerException(int statusCode, String responseBody) {
+        super(String.format("서버 오류 발생 (status=%d): %s", statusCode, responseBody));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,6 @@ spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
+
+kakao.client-id=""
+kakao.redirect-uri=http://localhost:8080/auth/kakao/callback

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,9 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 
-kakao.client-id=""
+spring.config.import=optional:file:secrets.properties
+
+kakao.client-id=${kakao.api.key}
 kakao.redirect-uri=http://localhost:8080/auth/kakao/callback
 kakao.auth-url=https://kauth.kakao.com/oauth/authorize
 kakao.token-url=https://kauth.kakao.com/oauth/token

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,5 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 
 kakao.client-id=""
 kakao.redirect-uri=http://localhost:8080/auth/kakao/callback
+kakao.auth-url=https://kauth.kakao.com/oauth/authorize
+kakao.token-url=https://kauth.kakao.com/oauth/token

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,9 +20,10 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 
-spring.config.import=optional:file:secrets.properties
+spring.config.import=optional:classpath:secrets.properties
 
 kakao.client-id=${kakao.api.key}
 kakao.redirect-uri=http://localhost:8080/auth/kakao/callback
 kakao.auth-url=https://kauth.kakao.com/oauth/authorize
 kakao.token-url=https://kauth.kakao.com/oauth/token
+kakao.user-info-url=https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## Step 1 - 카카오 로그인

✅ 구현 내용

- 카카오 로그인 인가 코드 받기 구현 (/auth/kakao/login)
- 인가 코드 수신 및 토큰 요청 처리 (/auth/kakao/callback)
- 외부 API와의 통신을 위해 `RestClient` 사용
- `application.properties`에 카카오 클라이언트 ID와 리다이렉트 URI 설정 추가
- 토큰 응답을 DTO로 매핑하여 향후 로직에 활용할 수 있도록 구현

💻 테스트

- 테스트 URL (로그인 시작): http://localhost:8080/auth/kakao/login


- 액세스 토큰 발급 확인

<img width="627" height="119" alt="image" src="https://github.com/user-attachments/assets/c585ae93-93f1-414f-bcc7-de49fd833ccd" />



