### PR TITLE
경북대 BE 이원준 1단계 - 카카오 로그인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Mac OS ###
 .DS_Store
+
+### env ###
+.env

--- a/src/main/java/gift/auth/config/JwtConfig.java
+++ b/src/main/java/gift/auth/config/JwtConfig.java
@@ -1,6 +1,5 @@
 package gift.auth.config;
 
-import gift.auth.domain.JwtProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/gift/auth/config/JwtProperties.java
+++ b/src/main/java/gift/auth/config/JwtProperties.java
@@ -1,4 +1,4 @@
-package gift.auth.domain;
+package gift.auth.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/gift/auth/config/KakaoOauthConfig.java
+++ b/src/main/java/gift/auth/config/KakaoOauthConfig.java
@@ -1,0 +1,10 @@
+package gift.auth.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(KakaoOauthProperties.class)
+public class KakaoOauthConfig {
+
+}

--- a/src/main/java/gift/auth/config/KakaoOauthProperties.java
+++ b/src/main/java/gift/auth/config/KakaoOauthProperties.java
@@ -1,0 +1,43 @@
+package gift.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakao")
+public record KakaoOauthProperties(
+    String clientId,
+    String clientSecret,
+    String redirectUri,
+    Urls urls
+) {
+
+    public record Urls(
+        String baseAuth,
+        String baseApi,
+        String token,
+        String authorize,
+        String userInfo,
+        String sendMessage,
+        String unlink
+    ) {
+
+        public String getTokenUrl() {
+            return baseAuth + token;
+        }
+
+        public String getAuthorizeUrl() {
+            return baseAuth + authorize;
+        }
+
+        public String getUserInfoUrl() {
+            return baseApi + userInfo;
+        }
+
+        public String getSendMessageUrl() {
+            return baseApi + sendMessage;
+        }
+
+        public String getUnlinkUrl() {
+            return baseApi + unlink;
+        }
+    }
+}

--- a/src/main/java/gift/auth/config/KakaoOauthProperties.java
+++ b/src/main/java/gift/auth/config/KakaoOauthProperties.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record KakaoOauthProperties(
     String clientId,
     String clientSecret,
+    String authorizeUri,
     String redirectUri,
     Urls urls
 ) {

--- a/src/main/java/gift/auth/config/RestClientConfig.java
+++ b/src/main/java/gift/auth/config/RestClientConfig.java
@@ -1,0 +1,19 @@
+package gift.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+    @Bean
+    public RestClient.Builder restClientBuilder() {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(5000);
+
+        return RestClient.builder()
+            .requestFactory(factory);
+    }
+}

--- a/src/main/java/gift/auth/config/SecurityConfig.java
+++ b/src/main/java/gift/auth/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -67,6 +68,6 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/gift/auth/controller/KakaoLoginController.java
+++ b/src/main/java/gift/auth/controller/KakaoLoginController.java
@@ -1,0 +1,39 @@
+package gift.auth.controller;
+
+import gift.auth.config.KakaoOauthProperties;
+import gift.auth.dto.KakaoTokenResponseDto;
+import gift.auth.dto.LoginResponseDto;
+import gift.auth.service.KakaoApiClient;
+import gift.auth.service.KakaoOauthService;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+@RequestMapping("/api/auth/kakao")
+public class KakaoLoginController {
+
+    private final KakaoOauthService kakaoOauthService;
+
+    public KakaoLoginController(KakaoOauthService kakaoOauthService) {
+        this.kakaoOauthService = kakaoOauthService;
+    }
+
+    @GetMapping("/login")
+    public void kakaoLogin(HttpServletResponse response) throws IOException {
+        String uri = kakaoOauthService.createAuthorizeRedirectUrl();
+        response.sendRedirect(uri);
+    }
+
+    @GetMapping("/callback")
+    public ResponseEntity<LoginResponseDto> redirectKakaoLogin(@RequestParam(name="code")String code){
+        return ResponseEntity.ok(kakaoOauthService.loginKakaoUser(code));
+    }
+
+}

--- a/src/main/java/gift/auth/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/gift/auth/dto/KakaoTokenResponseDto.java
@@ -1,0 +1,14 @@
+package gift.auth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoTokenResponseDto(
+    String tokenType,
+    String accessToken,
+    Integer expiresIn,
+    String refreshToken,
+    Integer refreshTokenExpiresIn,
+    String scope
+) {}

--- a/src/main/java/gift/auth/dto/KakaoUserInfoResponseDto.java
+++ b/src/main/java/gift/auth/dto/KakaoUserInfoResponseDto.java
@@ -1,0 +1,12 @@
+package gift.auth.dto;
+
+public record KakaoUserInfoResponseDto(
+    Long id,
+    Properties properties
+) {
+    public record Properties(
+        String nickname
+    ){
+
+    }
+}

--- a/src/main/java/gift/auth/dto/TextTemplate.java
+++ b/src/main/java/gift/auth/dto/TextTemplate.java
@@ -1,0 +1,22 @@
+package gift.auth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record TextTemplate(
+    String objectType,
+    String text,
+    Link link
+) {
+    public TextTemplate(String text, String url) {
+        this("text", text, new Link(url, url));
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record Link(
+        String webUrl,
+        String mobileWebUrl
+    ) {}
+}
+

--- a/src/main/java/gift/auth/exception/AuthErrorCode.java
+++ b/src/main/java/gift/auth/exception/AuthErrorCode.java
@@ -10,7 +10,9 @@ public enum AuthErrorCode implements ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-003", "만료된 토큰입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-004", "유효하지 않은 토큰입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH-005", "비밀번호가 일치하지 않습니다."),
-    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "AUTH-006", "해당 이메일을 사용중인 회원이 존재합니다.");
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "AUTH-006", "해당 이메일을 사용중인 회원이 존재합니다."),
+    KAKAO_CLIENT_ERROR(HttpStatus.BAD_REQUEST, "AUTH-007","카카오 API 클라이언트 오류"),
+    KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-008", "카카오 API 서버 오류");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/gift/auth/exception/AuthErrorCode.java
+++ b/src/main/java/gift/auth/exception/AuthErrorCode.java
@@ -12,7 +12,8 @@ public enum AuthErrorCode implements ErrorCode {
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH-005", "비밀번호가 일치하지 않습니다."),
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "AUTH-006", "해당 이메일을 사용중인 회원이 존재합니다."),
     KAKAO_CLIENT_ERROR(HttpStatus.BAD_REQUEST, "AUTH-007","카카오 API 클라이언트 오류"),
-    KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-008", "카카오 API 서버 오류");
+    KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH-008", "카카오 API 서버 오류"),
+    INVALID_LOGIN_EXCEPTION(HttpStatus.BAD_REQUEST, "AUTH-009","잘못된 로그인 요청입니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/gift/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/gift/auth/exception/AuthExceptionHandler.java
@@ -54,4 +54,28 @@ public class AuthExceptionHandler {
         return ErrorResponseFactory.createErrorResponse(exception);
     }
 
+    @ExceptionHandler(InvalidLoginException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidLoginException(
+        InvalidLoginException exception) {
+        logger.error("Invalid login exception: {}", exception.getMessage());
+
+        return ErrorResponseFactory.createErrorResponse(exception);
+    }
+
+    @ExceptionHandler(KakaoApiClientException.class)
+    public ResponseEntity<ErrorResponse> handleKakaoApiClientException(
+        KakaoApiClientException exception) {
+        logger.error("KakaoApiClient exception: {}", exception.getMessage());
+
+        return ErrorResponseFactory.createErrorResponse(exception);
+    }
+
+    @ExceptionHandler(KakaoApiServerException.class)
+    public ResponseEntity<ErrorResponse> handleKakaoApiServerException(
+        KakaoApiServerException exception) {
+        logger.error("KakaoApiServer exception: {}", exception.getMessage());
+
+        return ErrorResponseFactory.createErrorResponse(exception);
+    }
+
 }

--- a/src/main/java/gift/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/gift/auth/exception/AuthExceptionHandler.java
@@ -62,18 +62,10 @@ public class AuthExceptionHandler {
         return ErrorResponseFactory.createErrorResponse(exception);
     }
 
-    @ExceptionHandler(KakaoApiClientException.class)
-    public ResponseEntity<ErrorResponse> handleKakaoApiClientException(
+    @ExceptionHandler({KakaoApiClientException.class, KakaoApiServerException.class})
+    public ResponseEntity<ErrorResponse> handleKakaoApiException(
         KakaoApiClientException exception) {
-        logger.error("KakaoApiClient exception: {}", exception.getMessage());
-
-        return ErrorResponseFactory.createErrorResponse(exception);
-    }
-
-    @ExceptionHandler(KakaoApiServerException.class)
-    public ResponseEntity<ErrorResponse> handleKakaoApiServerException(
-        KakaoApiServerException exception) {
-        logger.error("KakaoApiServer exception: {}", exception.getMessage());
+        logger.error("Kakao Api exception: {}", exception.getMessage());
 
         return ErrorResponseFactory.createErrorResponse(exception);
     }

--- a/src/main/java/gift/auth/exception/InvalidLoginException.java
+++ b/src/main/java/gift/auth/exception/InvalidLoginException.java
@@ -1,0 +1,11 @@
+package gift.auth.exception;
+
+import gift.global.exception.BusinessException;
+import gift.global.exception.ErrorCode;
+
+public class InvalidLoginException extends BusinessException {
+
+    public InvalidLoginException() {
+        super(AuthErrorCode.INVALID_LOGIN_EXCEPTION);
+    }
+}

--- a/src/main/java/gift/auth/exception/KakaoApiClientException.java
+++ b/src/main/java/gift/auth/exception/KakaoApiClientException.java
@@ -1,0 +1,11 @@
+package gift.auth.exception;
+
+import gift.global.exception.BusinessException;
+
+public class KakaoApiClientException extends BusinessException {
+
+    public KakaoApiClientException(String text) {
+        super(AuthErrorCode.KAKAO_CLIENT_ERROR);
+        addArgument("status text",text);
+    }
+}

--- a/src/main/java/gift/auth/exception/KakaoApiServerException.java
+++ b/src/main/java/gift/auth/exception/KakaoApiServerException.java
@@ -1,0 +1,12 @@
+package gift.auth.exception;
+
+import gift.global.exception.BusinessException;
+import gift.global.exception.ErrorCode;
+
+public class KakaoApiServerException extends BusinessException {
+
+    public KakaoApiServerException(String text) {
+        super(AuthErrorCode.KAKAO_SERVER_ERROR);
+        addArgument("status text",text);
+    }
+}

--- a/src/main/java/gift/auth/service/AuthService.java
+++ b/src/main/java/gift/auth/service/AuthService.java
@@ -9,10 +9,12 @@ import gift.auth.dto.RegisterMemberRequestDto;
 import gift.auth.dto.RegisterMemberResponseDto;
 import gift.auth.exception.DuplicatedEmailException;
 import gift.auth.exception.ExpiredTokenException;
+import gift.auth.exception.InvalidLoginException;
 import gift.auth.exception.InvalidTokenException;
 import gift.auth.exception.PasswordMismatchException;
 import gift.auth.repository.MemberAuthJpaRepository;
 import gift.member.domain.Member;
+import gift.member.domain.MemberType;
 import gift.member.exception.MemberNotFoundException;
 import gift.member.repository.MemberJpaRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -44,7 +46,7 @@ public class AuthService {
             throw new DuplicatedEmailException();
         }
 
-        Member member = Member.of(dto.username());
+        Member member = Member.of(dto.username(), MemberType.GENERAL);
         Long memberId = memberRepository.save(member).getId();
         String encodedPassword = passwordEncoder.encode(dto.password());
 
@@ -67,6 +69,10 @@ public class AuthService {
 
         Member member = memberRepository.findById(memberAuth.getId())
             .orElseThrow(() -> new MemberNotFoundException(memberAuth.getId()));
+
+        if(member.isKakaoUser()){
+            throw new InvalidLoginException();
+        }
 
         TokenInfo tokenInfo = tokenService.generateBearerTokenInfo(member.getId(), email);
         return LoginResponseDto.from(tokenInfo);

--- a/src/main/java/gift/auth/service/KakaoApiClient.java
+++ b/src/main/java/gift/auth/service/KakaoApiClient.java
@@ -1,0 +1,120 @@
+package gift.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.auth.config.KakaoOauthProperties;
+import gift.auth.dto.KakaoTokenResponseDto;
+import gift.auth.dto.KakaoUserInfoResponseDto;
+import gift.auth.dto.TextTemplate;
+import gift.auth.exception.KakaoApiClientException;
+import gift.auth.exception.KakaoApiServerException;
+import java.net.URI;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class KakaoApiClient {
+
+    private final RestClient restClient;
+    private final KakaoOauthProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public KakaoApiClient(RestClient.Builder builder, KakaoOauthProperties properties, ObjectMapper objectMapper) {
+        this.restClient = builder
+            .defaultStatusHandler(HttpStatusCode::is4xxClientError, (request, response) -> {
+                throw new KakaoApiClientException(response.getStatusText());
+            })
+            .defaultStatusHandler(HttpStatusCode::is5xxServerError, (request, response) -> {
+                throw new KakaoApiServerException(response.getStatusText());
+            })
+            .build();
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    public KakaoTokenResponseDto getAccessToken(String code) {
+        URI uri = UriComponentsBuilder
+            .fromUriString(properties.urls().getTokenUrl())
+            .build()
+            .toUri();
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", properties.clientId());
+        body.add("redirect_uri", properties.redirectUri());
+        body.add("code", code);
+        body.add("client_secret", properties.clientSecret());
+
+        return restClient.post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(body)
+            .retrieve()
+            .body(KakaoTokenResponseDto.class);
+    }
+
+    public KakaoTokenResponseDto refreshAccessToken(String refreshToken){
+        URI uri = UriComponentsBuilder
+            .fromUriString(properties.urls().getTokenUrl())
+            .build()
+            .toUri();
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", properties.clientId());
+        body.add("refresh_token",refreshToken);
+        body.add("client_secret", properties.clientSecret());
+
+        return restClient.post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(body)
+            .retrieve()
+            .body(KakaoTokenResponseDto.class);
+    }
+
+    public KakaoUserInfoResponseDto getUserInfo(String kakaoAccessToken){
+        URI uri = UriComponentsBuilder
+            .fromUriString(properties.urls().getUserInfoUrl())
+            .build()
+            .toUri();
+
+        return restClient.get()
+            .uri(uri)
+            .header("Authorization", "Bearer " + kakaoAccessToken)
+            .retrieve()
+            .body(KakaoUserInfoResponseDto.class);
+    }
+
+    public void sendKakaoMessage(String kakaoAccessToken, String message){
+        URI uri = UriComponentsBuilder
+            .fromUriString(properties.urls().getSendMessageUrl())
+            .build()
+            .toUri();
+
+        TextTemplate template = new TextTemplate(message, "https://spring-gift.com");
+        String templateJson;
+        try {
+            templateJson = objectMapper.writeValueAsString(template);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("메시지 템플릿 직렬화 실패", e);
+        }
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("template_object",templateJson);
+
+        int resultCode = restClient.post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .header("Authorization", "Bearer " + kakaoAccessToken)
+            .body(body)
+            .retrieve()
+            .body(Integer.class);
+    }
+
+}

--- a/src/main/java/gift/auth/service/KakaoOauthService.java
+++ b/src/main/java/gift/auth/service/KakaoOauthService.java
@@ -1,0 +1,70 @@
+package gift.auth.service;
+
+import gift.auth.config.KakaoOauthProperties;
+import gift.auth.domain.MemberAuth;
+import gift.auth.domain.TokenInfo;
+import gift.auth.dto.KakaoTokenResponseDto;
+import gift.auth.dto.KakaoUserInfoResponseDto;
+import gift.auth.dto.LoginResponseDto;
+import gift.auth.dto.RegisterMemberResponseDto;
+import gift.auth.exception.DuplicatedEmailException;
+import gift.auth.repository.MemberAuthJpaRepository;
+import gift.auth.utils.EmailUtils;
+import gift.member.domain.Member;
+import gift.member.domain.MemberType;
+import gift.member.repository.MemberJpaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class KakaoOauthService {
+
+    private final MemberAuthJpaRepository memberAuthJpaRepository;
+    private final MemberJpaRepository memberJpaRepository;
+    private final KakaoApiClient kakaoApiClient;
+    private final TokenService tokenService;
+    private final KakaoOauthProperties properties;
+
+    public KakaoOauthService(MemberAuthJpaRepository memberAuthJpaRepository,
+        MemberJpaRepository memberJpaRepository, KakaoApiClient kakaoApiClient,
+        TokenService tokenService, KakaoOauthProperties properties) {
+        this.memberAuthJpaRepository = memberAuthJpaRepository;
+        this.memberJpaRepository = memberJpaRepository;
+        this.kakaoApiClient = kakaoApiClient;
+        this.tokenService = tokenService;
+        this.properties = properties;
+    }
+
+    public LoginResponseDto loginKakaoUser(String authorizationCode){
+        KakaoTokenResponseDto tokenResponse = kakaoApiClient.getAccessToken(authorizationCode);
+        KakaoUserInfoResponseDto userInfo = kakaoApiClient.getUserInfo(tokenResponse.accessToken());
+
+        //비즈니스 정책에 따른 이메일 생성
+        String email = EmailUtils.createEmailByKakaoId(userInfo.id());
+
+        //이메일 중복 검증
+        if(memberAuthJpaRepository.findByEmail(email).isPresent()){
+            throw new DuplicatedEmailException();
+        }
+
+        Member member = Member.of(userInfo.properties().nickname(), MemberType.KAKAO);
+        Long memberId = memberJpaRepository.save(member).getId();
+
+        MemberAuth memberAuth = MemberAuth.withId(memberId, email, "{noop}SOCIAL_LOGIN_USER");
+        memberAuthJpaRepository.save(memberAuth);
+
+        //서비스 자체 JWT발급
+        TokenInfo tokenInfo = tokenService.generateBearerTokenInfo(memberId, email);
+        return LoginResponseDto.from(tokenInfo);
+    }
+
+    public String createAuthorizeRedirectUrl() {
+        return UriComponentsBuilder.fromUriString(properties.authorizeUri())
+            .queryParam("scope", "talk_message")
+            .queryParam("response_type", "code")
+            .queryParam("redirect_uri", properties.redirectUri())
+            .queryParam("client_id", properties.clientId())
+            .build()
+            .toUriString();
+    }
+}

--- a/src/main/java/gift/auth/service/TokenService.java
+++ b/src/main/java/gift/auth/service/TokenService.java
@@ -1,6 +1,6 @@
 package gift.auth.service;
 
-import gift.auth.domain.JwtUtils;
+import gift.auth.utils.JwtUtils;
 import gift.auth.domain.MemberAuth;
 import gift.auth.domain.TokenInfo;
 import gift.auth.repository.MemberAuthJpaRepository;

--- a/src/main/java/gift/auth/utils/EmailUtils.java
+++ b/src/main/java/gift/auth/utils/EmailUtils.java
@@ -1,0 +1,9 @@
+package gift.auth.utils;
+
+public final class EmailUtils {
+    private static final String KAKAO_EMAIL_FORMAT = "kakaoUser%d@kakao.com";
+
+    public static String createEmailByKakaoId(Long kakaoId) {
+        return String.format(KAKAO_EMAIL_FORMAT, kakaoId);
+    }
+}

--- a/src/main/java/gift/auth/utils/JwtUtils.java
+++ b/src/main/java/gift/auth/utils/JwtUtils.java
@@ -1,5 +1,6 @@
-package gift.auth.domain;
+package gift.auth.utils;
 
+import gift.auth.config.JwtProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/java/gift/docs/Step4.md
+++ b/src/main/java/gift/docs/Step4.md
@@ -1,0 +1,43 @@
+# 🔐 3단계 - 카카오 로그인 연동
+
+해당 단계에서는 **카카오 로그인 기능을 도입**하여 외부 인증 기반 사용자 로그인 흐름을 처리할 수 있도록 구현하였습니다.  
+또한, **카카오톡 메시지 전송과 같은 API 활용을 위해 accessToken 발급 흐름까지 구성**하였으며, 추후 선택적 메시지 전송 기능으로 확장 가능한 구조로 설계하였습니다.
+
+---
+
+## ✅ 구현 내용
+
+### 📌 1. 카카오 로그인 요청 URL 생성 및 리다이렉트 처리
+
+- [x] `/api/auth/kakao/login` 요청 시, Kakao 인증 페이지로 리다이렉트
+- [x] 인증 요청 URL은 `KakaoOauthService`에서 생성하여 Controller의 책임을 분리
+
+### 📌 2. 카카오 인가 코드 수신 및 accessToken 발급
+
+- [x] `/api/auth/kakao/callback`에서 `code` 파라미터 수신
+- [x] `KakaoApiClient.getAccessToken(code)`를 통해 accessToken 및 refreshToken 발급
+- [x] `KakaoApiClient.getUserInfo(accessToken)` 호출로 사용자 정보(email, id) 조회
+
+### 📌 3. 카카오 회원 처리 및 JWT 발급
+
+- [x] 조회된 이메일 기반으로 기존 회원 여부 확인
+- [x] 없을 경우 `kakaoUser{ID}@kakao.com` 형식으로 사용자 등록
+- [x] 이후 `accessToken`, `refreshToken`을 생성하여 JWT 응답 반환
+
+### 📌 4. 기타 구성 요소
+
+- [x] `KakaoApiClient` 클래스에서 카카오 API 호출 책임 분리
+- [x] 인증 실패 및 서버 오류 대응을 위한 `KakaoApiClientException`, `KakaoApiServerException` 정의
+- [x] `application.yml`에 `client_id`, `client_secret`, 각종 카카오 API URL 설정 값 추가
+
+---
+
+## 🚀 향후 구현 계획
+
+- ✅ 테스트 코드 작성  
+  → 카카오 로그인 및 메시지 전송 흐름에 대한 통합 테스트, 예외 발생 케이스 검증
+
+- ✅ 자체 이메일 정책과 충돌 방지  
+  → 일반 회원가입 시 `@kakao.com` 도메인을 사용할 수 없도록 검증 로직 추가 예정
+
+---

--- a/src/main/java/gift/member/domain/Member.java
+++ b/src/main/java/gift/member/domain/Member.java
@@ -18,16 +18,20 @@ public class Member {
     @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false)
+    private MemberType memberType;
+
     protected Member() {
     }
 
-    private Member(Long id, String name) {
+    private Member(Long id, String name, MemberType memberType) {
         this.id = id;
         this.name = name;
+        this.memberType = memberType;
     }
 
-    public static Member of(String name) {
-        return new Member(null, name);
+    public static Member of(String name, MemberType memberType) {
+        return new Member(null, name, memberType);
     }
 
     public Long getId() {
@@ -36,5 +40,9 @@ public class Member {
 
     public String getName() {
         return name;
+    }
+
+    public boolean isKakaoUser(){
+        return this.memberType==MemberType.KAKAO;
     }
 }

--- a/src/main/java/gift/member/domain/MemberType.java
+++ b/src/main/java/gift/member/domain/MemberType.java
@@ -1,0 +1,5 @@
+package gift.member.domain;
+
+public enum MemberType {
+    GENERAL, KAKAO
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   thymeleaf:
     prefix: classpath:/templates/
     suffix: .html
@@ -8,6 +10,19 @@ jwt:
   access-token-validity: ${ACCESS_TOKEN_VALIDTY:3600000}
   refresh-token-validity: ${REFRESH_TOKEN_VALIDITY:604800000}
   issuer: ${ISSUER:http://auth.gift-app.com}
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/api/kakao/callback}
+  urls:
+    base-auth: https://kauth.kakao.com
+    base-api: https://kapi.kakao.com
+    token: /oauth/token
+    authorize: /oauth/authorize
+    user-info: /v2/user/me
+    send-message: /v2/api/talk/memo/default/send
+    unlink: /v1/user/unlink
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,8 @@ jwt:
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/api/kakao/callback}
+  authorize-uri: ${KAKAO_AUTAHORIZE_URI:https://kauth.kakao.com/oauth/authorize}
+  redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/api/auth/kakao/callback}
   urls:
     base-auth: https://kauth.kakao.com
     base-api: https://kapi.kakao.com

--- a/src/main/resources/data-default.sql
+++ b/src/main/resources/data-default.sql
@@ -22,8 +22,8 @@ INSERT INTO product (id, name, price, description, image_url)
 VALUES (110, '테스트 상품10', 10000, '설명10', 'https://img.url');
 
 
-INSERT INTO member (id, name)
-VALUES (100, 'lee');
+INSERT INTO member (id, name, member_type)
+VALUES (100, 'lee', 0);
 
 
 INSERT INTO member_auth (id, email, password, refresh_token)

--- a/src/test/java/gift/auth/service/KakaoApiClientTest.java
+++ b/src/test/java/gift/auth/service/KakaoApiClientTest.java
@@ -1,0 +1,197 @@
+package gift.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.auth.config.KakaoOauthProperties;
+import gift.auth.dto.KakaoTokenResponseDto;
+import gift.auth.dto.KakaoUserInfoResponseDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+class KakaoApiClientTest {
+
+    private KakaoApiClient kakaoApiClient;
+    private MockRestServiceServer mockServer;
+    private KakaoOauthProperties kakaoOauthProperties;
+
+    @BeforeEach
+    void setUp() {
+        KakaoOauthProperties.Urls urls = mock(KakaoOauthProperties.Urls.class);
+        when(urls.getTokenUrl()).thenReturn("https://kauth.kakao.com/oauth/token");
+        when(urls.getUserInfoUrl()).thenReturn("https://kapi.kakao.com/v2/user/me");
+        when(urls.getSendMessageUrl()).thenReturn("https://kapi.kakao.com/v2/api/talk/memo/default/send");
+
+        kakaoOauthProperties = mock(KakaoOauthProperties.class);
+        when(kakaoOauthProperties.urls()).thenReturn(urls);
+        when(kakaoOauthProperties.clientId()).thenReturn("client-id");
+        when(kakaoOauthProperties.redirectUri()).thenReturn("http://localhost/callback");
+        when(kakaoOauthProperties.clientSecret()).thenReturn("client-secret");
+
+        RestClient.Builder restClientBuilder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+        kakaoApiClient = new KakaoApiClient(restClientBuilder, kakaoOauthProperties, new ObjectMapper());
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.reset();
+    }
+
+    @Test
+    void getAccessToken() {
+        String responseJson = """
+            {
+                "token_type": "bearer",
+                "access_token": "access-token",
+                "expires_in": 3600,
+                "refresh_token": "refresh-token",
+                "refresh_token_expires_in": 2592000,
+                "scope": "profile"
+            }
+            """;
+
+        MultiValueMap<String, String> expectedForm = new LinkedMultiValueMap<>();
+        expectedForm.add("grant_type", "authorization_code");
+        expectedForm.add("client_id", "client-id");
+        expectedForm.add("redirect_uri", "http://localhost/callback");
+        expectedForm.add("code", "auth-code");
+        expectedForm.add("client_secret", "client-secret");
+
+        mockServer.expect(requestTo("https://kauth.kakao.com/oauth/token"))
+            .andExpect(method(org.springframework.http.HttpMethod.POST))
+            .andExpect(content().formData(expectedForm))
+            .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
+
+        KakaoTokenResponseDto result = kakaoApiClient.getAccessToken("auth-code");
+
+        assertAll(
+            () -> assertThat(result.tokenType()).isEqualTo("bearer"),
+            () -> assertThat(result.accessToken()).isEqualTo("access-token"),
+            () -> assertThat(result.expiresIn()).isEqualTo(3600),
+            () -> assertThat(result.refreshToken()).isEqualTo("refresh-token"),
+            () -> assertThat(result.refreshTokenExpiresIn()).isEqualTo(2592000),
+            () -> assertThat(result.scope()).isEqualTo("profile")
+        );
+
+        mockServer.verify();
+    }
+
+    @Test
+    void refreshAccessToken() {
+        String responseJson = """
+            {
+                "token_type": "bearer",
+                "access_token": "new-access-token",
+                "expires_in": 3600,
+                "refresh_token": "new-refresh-token",
+                "refresh_token_expires_in": 2592000,
+                "scope": "profile"
+            }
+            """;
+
+        MultiValueMap<String, String> expectedForm = new LinkedMultiValueMap<>();
+        expectedForm.add("grant_type", "authorization_code");
+        expectedForm.add("client_id", "client-id");
+        expectedForm.add("refresh_token", "refresh-token");
+        expectedForm.add("client_secret", "client-secret");
+
+        mockServer.expect(requestTo("https://kauth.kakao.com/oauth/token"))
+            .andExpect(method(org.springframework.http.HttpMethod.POST))
+            .andExpect(content().formData(expectedForm))
+            .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
+
+        KakaoTokenResponseDto result = kakaoApiClient.refreshAccessToken("refresh-token");
+
+        assertAll(
+            () -> assertThat(result.tokenType()).isEqualTo("bearer"),
+            () -> assertThat(result.accessToken()).isEqualTo("new-access-token"),
+            () -> assertThat(result.expiresIn()).isEqualTo(3600),
+            () -> assertThat(result.refreshToken()).isEqualTo("new-refresh-token"),
+            () -> assertThat(result.refreshTokenExpiresIn()).isEqualTo(2592000),
+            () -> assertThat(result.scope()).isEqualTo("profile")
+        );
+
+        mockServer.verify();
+    }
+
+    @Test
+    void getUserInfo() {
+        String responseJson = """
+            {
+                "id": 12345,
+                "properties": {
+                    "nickname": "테스트유저"
+                }
+            }
+            """;
+
+        mockServer.expect(requestTo("https://kapi.kakao.com/v2/user/me"))
+            .andExpect(method(org.springframework.http.HttpMethod.GET))
+            .andExpect(header("Authorization", "Bearer access-token"))
+            .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
+
+        KakaoUserInfoResponseDto result = kakaoApiClient.getUserInfo("access-token");
+
+        assertAll(
+            () -> assertThat(result).isNotNull(),
+            () -> assertThat(result.id()).isEqualTo(12345L),
+            () -> assertThat(result.properties()).isNotNull(),
+            () -> assertThat(result.properties().nickname()).isEqualTo("테스트유저")
+        );
+
+        mockServer.verify();
+    }
+
+    @Test
+    void sendKakaoMessage() {
+        mockServer.expect(requestTo("https://kapi.kakao.com/v2/api/talk/memo/default/send"))
+            .andExpect(method(org.springframework.http.HttpMethod.POST))
+            .andExpect(header("Authorization", "Bearer access-token"))
+            .andExpect(content().contentType(MediaType.APPLICATION_FORM_URLENCODED))
+            .andExpect(content().string(containsString("template_object=")))
+            .andRespond(withSuccess("0", MediaType.APPLICATION_JSON));
+
+        assertThatNoException().isThrownBy(() ->
+            kakaoApiClient.sendKakaoMessage("access-token", "test message")
+        );
+
+        mockServer.verify();
+    }
+
+    @Test
+    void getAccessToken_withError() {
+        mockServer.expect(requestTo("https://kauth.kakao.com/oauth/token"))
+            .andExpect(method(org.springframework.http.HttpMethod.POST))
+            .andRespond(withBadRequest().body("Invalid request"));
+
+        assertThatThrownBy(() -> kakaoApiClient.getAccessToken("invalid-code"))
+            .isInstanceOf(Exception.class);
+
+        mockServer.verify();
+    }
+
+    @Test
+    void getUserInfo_withError() {
+        mockServer.expect(requestTo("https://kapi.kakao.com/v2/user/me"))
+            .andExpect(method(org.springframework.http.HttpMethod.GET))
+            .andExpect(header("Authorization", "Bearer invalid-token"))
+            .andRespond(withUnauthorizedRequest().body("Invalid token"));
+
+        assertThatThrownBy(() -> kakaoApiClient.getUserInfo("invalid-token"))
+            .isInstanceOf(Exception.class);
+
+        mockServer.verify();
+    }
+}

--- a/src/test/java/gift/wishlist/repository/WishItemJpaRepositoryTest.java
+++ b/src/test/java/gift/wishlist/repository/WishItemJpaRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import gift.member.domain.Member;
+import gift.member.domain.MemberType;
 import gift.product.domain.Product;
 import gift.product.domain.ProductOption;
 import gift.wishlist.domain.WishItem;
@@ -34,7 +35,7 @@ class WishItemJpaRepositoryTest {
     @Test
     @DisplayName("위시아이템을 저장하고 조회할 수 있다")
     void saveAndFindWishItem() {
-        Member member = Member.of("lee");
+        Member member = Member.of("lee", MemberType.GENERAL);
         Product product = Product.of("testProduct", 1000, "description", "image.jpg",
             List.of(ProductOption.of("testOption", 10)));
 
@@ -55,7 +56,7 @@ class WishItemJpaRepositoryTest {
     @Test
     @DisplayName("멤버ID와 상품ID로 위시아이템을 조회할 수 있다")
     void findByMemberIdAndProductId() {
-        Member member = Member.of("lee");
+        Member member = Member.of("lee", MemberType.GENERAL);
         Product product = Product.of("testProduct", 1000, "description", "image.jpg",
             List.of(ProductOption.of("testOption", 10)));
 
@@ -86,7 +87,7 @@ class WishItemJpaRepositoryTest {
     @Test
     @DisplayName("멤버ID로 상품 정보와 함께 위시아이템 목록을 페이지네이션으로 조회할 수 있다")
     void findAllWithProductByMemberId_withPaging() {
-        Member member = Member.of("lee");
+        Member member = Member.of("lee", MemberType.GENERAL);
         Product product1 = Product.of("testProduct", 1000, "description", "image.jpg",
             List.of(ProductOption.of("testOption", 10)));
         Product product2 = Product.of("testProduct", 2000, "description", "image.jpg",
@@ -134,7 +135,7 @@ class WishItemJpaRepositoryTest {
     @Test
     @DisplayName("위시아이템을 삭제할 수 있다")
     void deleteWishItem() {
-        Member member = Member.of("lee");
+        Member member = Member.of("lee", MemberType.GENERAL);
         Product product = Product.of("testProduct", 800000, "description", "image.jpg",
             List.of(ProductOption.of("testOption", 10)));
 
@@ -154,7 +155,7 @@ class WishItemJpaRepositoryTest {
     @Test
     @DisplayName("ID로 위시아이템을 조회할 수 있다")
     void findById() {
-        Member member = Member.of("lee");
+        Member member = Member.of("lee", MemberType.GENERAL);
         Product product = Product.of("testProduct", 1000, "description", "image.jpg",
             List.of(ProductOption.of("testOption", 10)));
 
@@ -176,8 +177,8 @@ class WishItemJpaRepositoryTest {
     @Test
     @DisplayName("전체 위시아이템 수를 조회할 수 있다")
     void countAllWishItems() {
-        Member member1 = Member.of("lee");
-        Member member2 = Member.of("kim");
+        Member member1 = Member.of("lee", MemberType.GENERAL);
+        Member member2 = Member.of("kim", MemberType.GENERAL);
         Product product1 = Product.of("testProduct", 1000, "description", "image.jpg",
             List.of(ProductOption.of("testOption", 10)));
         Product product2 = Product.of("testProduct", 2000, "description", "image.jpg",
@@ -202,7 +203,7 @@ class WishItemJpaRepositoryTest {
     @Test
     @DisplayName("위시아이템이 존재하는지 확인할 수 있다")
     void existsById() {
-        Member member = Member.of("lee");
+        Member member = Member.of("lee", MemberType.GENERAL);
         Product product = Product.of("testProduct", 1000, "description", "image.jpg",
             List.of(ProductOption.of("testOption", 10)));
 


### PR DESCRIPTION
## ✅ 구현 사항

### 카카오 로그인 기능 구현

- `/api/auth/kakao/login`: 카카오 로그인 페이지로 리다이렉트
- `/api/auth/kakao/callback`: 인가 코드 수신 → Access Token 발급 → 사용자 정보 조회 → 회원가입/로그인 처리 → JWT 발급
- 카카오 로그인 전용 사용자 이메일 정책 적용: `kakaoUser{id}@kakao.com` 형식
- 멤버 타입(`MemberType`)을 통해 일반 사용자와 카카오 사용자를 구분

---

## 🤔 고민한 점

- **RestTemplate, WebClient, RestClient 선택 기준**
 RestTemplate은 deprecated 예정이고 WebClient는 주로 비동기 목적이고 Mono와 같은 비동기 관련 개념을 학습해야하는 러닝커브가 있어서 RestClient를 선택하였습니다

- **카카오 API관련 속성값 환경변수로 관리할지, yml을 분리할지**  
  변경에 유연한 환경변수 방식으로 카카오 API관련 속성값 관리를 하기로 했습니다.

- **카카오 API URI도 환경변수로 관리할지**
  URI도 API 버전이 업데이트 됨에 따라 변경이 꽤 일어난다고 판단해 상수보다 환경변수로 빼서 관리하도록 했습니다.

- **RestClient를 Builder로 주입할지 직접 만들지**  
  테스트나 확장성을 생각하면 주입이 더 나은 것 같아서 Builder 주입 방식으로 정리했습니다.

- **카카오 소셜 로그인 회원 이메일(식별자) 처리**  
  카카오에서 이메일을 받으려면 비즈 앱 등록이 필요한데, 지금은 개인 앱이라 어려워서 `kakaoUser{id}@kakao.com` 형식으로 자체 정책을 정하는 방식으로 구현했습니다!

- **카카오 소셜 로그인 회원 비밀번호 처리 방식**  
  NPE 방지 차원에서 null보다 `{noop}`를 붙인 더미 비밀번호가 안전하다고 생각해서 해당 방식으로 구현했고, MemberType으로 일반 로그인/카카오 소셜 로그인를 구분하는 방식을 선택했습니다.

---

## 🙏 중점적으로 리뷰 받고 싶은 부분

###  카카오 access token / refresh token 저장 전략

- 향후 **카카오 메시지 API** 사용을 고려하면 카카오 access token을 저장할 필요가 있다고 생각하는데, 현재 서비스 자체 JWT 토큰과 **카카오 access/refresh token**을 어떤 방식으로 **구분·관리**하는 것이 좋을지 방향성에 대한 조언 부탁드립니다

### KakaoApiClient 테스트 방식의 적절성
- 외부 API 호출에 대한 테스트는 처음이라 적절하게 테스트 코드를 작성했는지 확신이 안듭니다.
- 관련 문서를 읽어보며 `RestClient` 기반으로 `MockRestServiceServer`를 사용해 외부 API 호출 테스트 진행했는데 테스트 방식이 외부 API 테스트로 적절한지 혹은 더 나은 테스트 전략이 있다면 어떤 것이 있을지 조언해주시면 감사하겠습니다!
