### PR TITLE
전남대 최지민 Step2 주문하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # spring-gift-order
+
+### 환경 변수 관리
+`KAKAO_API_KEY`= # 카카오 REST API 키  
+`REDIRECT_URL`= # 카카오 로그인 인증 리다이렉트 URL

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6' // or 'io.jsonwebtoken:jjwt-gson:0.12.6' for gson
 
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
+
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/gift/config/AesException.java
+++ b/src/main/java/gift/config/AesException.java
@@ -1,0 +1,8 @@
+package gift.config;
+
+public class AesException extends RuntimeException {
+
+    public AesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/gift/config/GlobalExceptionHandler.java
+++ b/src/main/java/gift/config/GlobalExceptionHandler.java
@@ -61,5 +61,10 @@ public class GlobalExceptionHandler {
         ErrorResponse error = new ErrorResponse(e.getMessage(), e.getHttpStatus().value());
         return ResponseEntity.status(e.getHttpStatus()).body(error);
     }
+    @ExceptionHandler(AesException.class)
+    public ResponseEntity<ErrorResponse> aesException(AesException ex) {
+        ErrorResponse response = new ErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST.value());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
 
 }

--- a/src/main/java/gift/config/GlobalExceptionHandler.java
+++ b/src/main/java/gift/config/GlobalExceptionHandler.java
@@ -55,4 +55,11 @@ public class GlobalExceptionHandler {
         ErrorResponse response = new ErrorResponse(ex.getMessage(), HttpStatus.UNAUTHORIZED.value());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(KakaoAuthException.class)
+    public ResponseEntity<ErrorResponse> handleKakaoAuth(KakaoAuthException e) {
+        ErrorResponse error = new ErrorResponse(e.getMessage(), e.getHttpStatus().value());
+        return ResponseEntity.status(e.getHttpStatus()).body(error);
+    }
+
 }

--- a/src/main/java/gift/config/JwtTokenProvider.java
+++ b/src/main/java/gift/config/JwtTokenProvider.java
@@ -1,10 +1,13 @@
 package gift.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Date;
 import org.springframework.stereotype.Component;
 
@@ -44,5 +47,23 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
+    }
+
+    public String extractNickname(String idToken) {
+        try {
+            String[] parts = idToken.split("\\.");
+            String payload = parts[1];
+
+            byte[] decodedBytes = Base64.getUrlDecoder().decode(payload);
+            String decodedJson = new String(decodedBytes);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode root = objectMapper.readTree(decodedJson);
+
+            return root.has("nickname") ? root.get("nickname").asText() : null;
+
+        } catch (Exception e) {
+            throw new RuntimeException("JWT nickname 추출 실패", e);
+        }
     }
 }

--- a/src/main/java/gift/config/JwtTokenProvider.java
+++ b/src/main/java/gift/config/JwtTokenProvider.java
@@ -1,15 +1,31 @@
 package gift.config;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.dto.Jwk;
+import gift.dto.JwkSet;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
 
 @Component
 public class JwtTokenProvider {
@@ -17,6 +33,9 @@ public class JwtTokenProvider {
     private final String secretKey = "SecretKey12345678901234567890123456789012123145423123411441";
 
     private final long expirationMs = 1000 * 60 * 60; // 1시간
+
+    @Value("${kakao.api.key}")
+    private String API_KEY;
 
     public String createToken(String email) {
         return Jwts.builder()
@@ -50,21 +69,89 @@ public class JwtTokenProvider {
     }
 
     public String extractEmail(String idToken) {
-        try {
-            String[] parts = idToken.split("\\.");
-            String payload = parts[1];
+        if (!validateIdToken(idToken)) {
+            throw new UnAuthorizationException("유효하지 않은 id token 입니다.");
+        }
+        String[] parts = idToken.split("\\.");
+        String payload = parts[1];
+        JsonNode root = decodeBase64Json(payload);
 
-            byte[] decodedBytes = Base64.getUrlDecoder().decode(payload);
+        return root.has("email") ? root.get("email").asText() : null;
+    }
+
+    public boolean validateIdToken(String idToken) {
+        String[] parts = idToken.split("\\.");
+        String header = parts[0];
+        String payload = parts[1];
+
+        return validatePayload(payload) && validateSignature(header, payload, parts);
+    }
+
+    private static boolean validateSignature(String header, String payload, String[] parts)  {
+        JsonNode headerJson = decodeBase64Json(header);
+        String kidByIdToken = headerJson.has("kid") ? headerJson.get("kid").asText() : null;
+        if (kidByIdToken == null) {
+            throw new UnAuthorizationException("ID 토큰에 kid 값이 없습니다.");
+        }
+        RestClient client = RestClient.builder().baseUrl("https://kauth.kakao.com/.well-known/jwks.json").build();
+        JwkSet jwkSet = client.get().retrieve()
+                .body(new ParameterizedTypeReference<JwkSet>() {
+                });
+
+        Jwk matchingJwk = jwkSet.keys().stream().filter(jwk -> jwk.kid().equals(kidByIdToken))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("공개키를 찾을 수 없습니다."));
+        PublicKey publicKey = buildRSAPublicKey(matchingJwk.n(), matchingJwk.e());
+
+        return verifySignature(header + "." + payload, Base64.getUrlDecoder().decode(parts[2]), publicKey);
+    }
+
+    private boolean validatePayload(String payload) {
+        JsonNode jsonNode = decodeBase64Json(payload);
+        String iss = jsonNode.has("iss") ? jsonNode.get("iss").asText() : null;
+        String aud = jsonNode.has("aud") ? jsonNode.get("aud").asText() : null;
+        Long exp = jsonNode.has("exp") ? jsonNode.get("exp").asLong() : null;
+
+        if (iss == null || aud == null || exp == null) {
+            throw new UnAuthorizationException("idToken이 유효하지 않습니다.");
+        }
+        return iss.equals("https://kauth.kakao.com") && aud.equals(API_KEY) && Instant.now().isBefore(Instant.ofEpochSecond(exp));
+    }
+
+    public static boolean verifySignature(String headerPayload, byte[] signatureBytes, PublicKey publicKey) {
+        Signature signature = null;
+        try {
+            signature = Signature.getInstance("SHA256withRSA");
+            signature.initVerify(publicKey);
+            signature.update(headerPayload.getBytes(StandardCharsets.UTF_8));
+            return signature.verify(signatureBytes);
+        } catch (NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
+            throw new RuntimeException("서명 검증 실패", e);
+        }
+    }
+
+    private static JsonNode decodeBase64Json(String jwt)  {
+        try {
+            byte[] decodedBytes = Base64.getUrlDecoder().decode(jwt);
             String decodedJson = new String(decodedBytes);
 
             ObjectMapper objectMapper = new ObjectMapper();
             JsonNode root = objectMapper.readTree(decodedJson);
-            System.out.println(root);
+            return root;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JWt 추출 실패", e);
+        }
+    }
 
-            return root.has("email") ? root.get("email").asText() : null;
-
-        } catch (Exception e) {
-            throw new RuntimeException("JWT nickname 추출 실패", e);
+    public static PublicKey buildRSAPublicKey(String nBase64Url, String eBase64Url) {
+        BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(nBase64Url));
+        BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(eBase64Url));
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(modulus, exponent);
+        KeyFactory keyFactory = null;
+        try {
+            keyFactory = KeyFactory.getInstance("RSA");
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException("RSA 공개키 생성 실패",e);
         }
     }
 }

--- a/src/main/java/gift/config/JwtTokenProvider.java
+++ b/src/main/java/gift/config/JwtTokenProvider.java
@@ -49,7 +49,7 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
-    public String extractNickname(String idToken) {
+    public String extractEmail(String idToken) {
         try {
             String[] parts = idToken.split("\\.");
             String payload = parts[1];
@@ -59,8 +59,9 @@ public class JwtTokenProvider {
 
             ObjectMapper objectMapper = new ObjectMapper();
             JsonNode root = objectMapper.readTree(decodedJson);
+            System.out.println(root);
 
-            return root.has("nickname") ? root.get("nickname").asText() : null;
+            return root.has("email") ? root.get("email").asText() : null;
 
         } catch (Exception e) {
             throw new RuntimeException("JWT nickname 추출 실패", e);

--- a/src/main/java/gift/config/KakaoAuthException.java
+++ b/src/main/java/gift/config/KakaoAuthException.java
@@ -1,0 +1,18 @@
+package gift.config;
+
+import org.springframework.http.HttpStatusCode;
+
+public class KakaoAuthException extends RuntimeException {
+
+
+    private final HttpStatusCode httpStatus;
+
+    public KakaoAuthException(String message, Throwable cause, HttpStatusCode httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public HttpStatusCode getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -26,7 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .order(1)
                 .addPathPatterns(
                         "/api/wishes/**",
-                        "/css/**", "/*.ico", "/error"
+                        "/api/orders"
                 );
     }
 
@@ -38,9 +38,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Bean
     public RestClient kakaoRestClient() {
-        return RestClient.builder()
-                .baseUrl("https://kauth.kakao.com")
-                .build();
+        return RestClient.create();
     }
 
 }

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -1,9 +1,11 @@
 package gift.config;
 
 import gift.login.LoginArgumentResolver;
+import java.time.Duration;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -38,7 +40,14 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Bean
     public RestClient kakaoRestClient() {
-        return RestClient.create();
+        HttpComponentsClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory();
+        clientHttpRequestFactory.setConnectTimeout(3000);
+        clientHttpRequestFactory.setConnectionRequestTimeout(3000);
+        clientHttpRequestFactory.setReadTimeout(3000);
+
+        return RestClient.builder()
+                .requestFactory(clientHttpRequestFactory)
+                .build();
     }
 
 }

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -2,7 +2,9 @@ package gift.config;
 
 import gift.login.LoginArgumentResolver;
 import java.util.List;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -33,4 +35,12 @@ public class WebConfig implements WebMvcConfigurer {
         resolvers.add(loginArgumentResolver);
         WebMvcConfigurer.super.addArgumentResolvers(resolvers);
     }
+
+    @Bean
+    public RestClient kakaoRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://kauth.kakao.com")
+                .build();
+    }
+
 }

--- a/src/main/java/gift/controller/KakaoController.java
+++ b/src/main/java/gift/controller/KakaoController.java
@@ -1,5 +1,6 @@
 package gift.controller;
 
+import gift.dto.LoginMemberResponse;
 import gift.service.KakaoService;
 import java.net.URI;
 import org.springframework.http.HttpStatus;
@@ -26,8 +27,8 @@ public class KakaoController {
     }
 
     @GetMapping
-    public ResponseEntity<Void> getAccessToken(@RequestParam("code") String code) {
-        service.getAccessToken(code);
-        return ResponseEntity.status(HttpStatus.OK).build();
+    public ResponseEntity<LoginMemberResponse> getAccessToken(@RequestParam("code") String code) {
+        String token = service.getAccessToken(code);
+        return new ResponseEntity<>(new LoginMemberResponse(token), HttpStatus.OK);
     }
 }

--- a/src/main/java/gift/controller/KakaoController.java
+++ b/src/main/java/gift/controller/KakaoController.java
@@ -2,7 +2,6 @@ package gift.controller;
 
 import gift.service.KakaoService;
 import java.net.URI;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,23 +13,13 @@ public class KakaoController {
 
     private final KakaoService service;
 
-    @Value("${kakao.api.key}")
-    private String apiKey;
-
-    @Value("${redirect.url}")
-    private String redirectUrl;
-
     public KakaoController(KakaoService service) {
         this.service = service;
     }
 
     @GetMapping("/oauth/login")
     public ResponseEntity<Void> redirectToKakao() {
-        URI uri = URI.create("https://kauth.kakao.com/oauth/authorize" +
-                "?response_type=code" +
-                "&client_id=" + apiKey +
-                "&redirect_uri="+ redirectUrl);
-
+        URI uri = service.getOauthUri();
         return ResponseEntity.status(HttpStatus.FOUND)
                 .location(uri)
                 .build();

--- a/src/main/java/gift/controller/OrderController.java
+++ b/src/main/java/gift/controller/OrderController.java
@@ -23,11 +23,10 @@ public class OrderController {
 
 
     @PostMapping("/api/orders")
-    public HttpEntity<OrdersResponse> createOrders(@RequestBody OrdersRequest request, @Login
-            LoginMember loginMember) {
-        OrdersResponse response = orderService.createOrder(loginMember.id(), request.optionId(),
-                request.quantity(),
-                request.message());
+    public HttpEntity<OrdersResponse> createOrders(
+            @RequestBody OrdersRequest request,
+            @Login LoginMember loginMember) {
+        OrdersResponse response = orderService.createOrder(loginMember.id(), request);
 
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }

--- a/src/main/java/gift/controller/OrderController.java
+++ b/src/main/java/gift/controller/OrderController.java
@@ -1,0 +1,34 @@
+package gift.controller;
+
+import gift.dto.OrdersRequest;
+import gift.dto.OrdersResponse;
+import gift.login.Login;
+import gift.login.LoginMember;
+import gift.service.OrderService;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+
+    @PostMapping("/api/orders")
+    public HttpEntity<OrdersResponse> createOrders(@RequestBody OrdersRequest request, @Login
+            LoginMember loginMember) {
+        OrdersResponse response = orderService.createOrder(loginMember.id(), request.optionId(),
+                request.quantity(),
+                request.message());
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/gift/domain/AccountType.java
+++ b/src/main/java/gift/domain/AccountType.java
@@ -1,0 +1,6 @@
+package gift.domain;
+
+public enum AccountType {
+    LOCAL,
+    KAKAO
+}

--- a/src/main/java/gift/domain/KakaoToken.java
+++ b/src/main/java/gift/domain/KakaoToken.java
@@ -56,7 +56,8 @@ public class KakaoToken {
         return accessTokenExpiresAt;
     }
 
-    public void renewAccessToken(String accessToken) {
+    public void renewAccessToken(String accessToken, LocalDateTime accessTokenExpiresAt) {
+        renewAccessTokenExpiresAt(accessTokenExpiresAt);
         this.accessToken = accessToken;
     }
 
@@ -66,5 +67,9 @@ public class KakaoToken {
 
     public void renewAccessTokenExpiresAt(LocalDateTime accessTokenExpiresAt) {
         this.accessTokenExpiresAt = accessTokenExpiresAt;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.getAccessTokenExpiresAt());
     }
 }

--- a/src/main/java/gift/domain/KakaoToken.java
+++ b/src/main/java/gift/domain/KakaoToken.java
@@ -1,0 +1,70 @@
+package gift.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+
+@Entity
+public class KakaoToken {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "kakao_token_id")
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String accessToken;
+    private String refreshToken;
+    private LocalDateTime accessTokenExpiresAt;
+
+    public KakaoToken() {
+    }
+
+    public KakaoToken(Long id, Member member, String accessToken, String refreshToken,
+            LocalDateTime accessTokenExpiresAt) {
+        this.id = id;
+        this.member = member;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.accessTokenExpiresAt = accessTokenExpiresAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public LocalDateTime getAccessTokenExpiresAt() {
+        return accessTokenExpiresAt;
+    }
+
+    public void renewAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public void renewRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void renewAccessTokenExpiresAt(LocalDateTime accessTokenExpiresAt) {
+        this.accessTokenExpiresAt = accessTokenExpiresAt;
+    }
+}

--- a/src/main/java/gift/domain/KakaoToken.java
+++ b/src/main/java/gift/domain/KakaoToken.java
@@ -24,7 +24,7 @@ public class KakaoToken {
     private String refreshToken;
     private LocalDateTime accessTokenExpiresAt;
 
-    public KakaoToken() {
+    protected KakaoToken() {
     }
 
     public KakaoToken(Long id, Member member, String accessToken, String refreshToken,

--- a/src/main/java/gift/domain/Member.java
+++ b/src/main/java/gift/domain/Member.java
@@ -34,7 +34,7 @@ public class Member {
         this.accountType = accountType;
     }
 
-    public Member() {
+    protected Member() {
     }
 
     public String getSalt() {

--- a/src/main/java/gift/domain/Member.java
+++ b/src/main/java/gift/domain/Member.java
@@ -13,16 +13,25 @@ public class Member {
     @Column(unique = true, nullable = false)
     private String email;
 
-    @Column(nullable = false)
     private String password;
 
     private String salt;
+
+    @Enumerated(value = EnumType.STRING)
+    private AccountType accountType;
 
     public Member(Long id, String email, String password, String salt) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.salt = salt;
+    }
+    public Member(Long id, String email, String password, String salt, AccountType accountType) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.salt = salt;
+        this.accountType = accountType;
     }
 
     public Member() {

--- a/src/main/java/gift/domain/Option.java
+++ b/src/main/java/gift/domain/Option.java
@@ -30,7 +30,7 @@ public class Option {
 
     private static final Pattern FORBIDDEN = Pattern.compile("[^a-zA-Z0-9가-힣()\\[\\]+\\-&/_]");
 
-    public Option() {
+    protected Option() {
     }
 
     public Option(Long id, String name, int quantity, Product product) {

--- a/src/main/java/gift/domain/Orders.java
+++ b/src/main/java/gift/domain/Orders.java
@@ -1,0 +1,51 @@
+package gift.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Orders {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String message;
+
+    private int quantity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id")
+    private Option option;
+
+    protected Orders() {
+    }
+
+    public Orders(Long id, String message, int quantity, Option option) {
+        this.id = id;
+        this.message = message;
+        this.quantity = quantity;
+        this.option = option;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public Option getOption() {
+        return option;
+    }
+}

--- a/src/main/java/gift/domain/Product.java
+++ b/src/main/java/gift/domain/Product.java
@@ -31,7 +31,7 @@ public class Product {
         this.imageUrl = imageUrl;
     }
 
-    public Product() {
+    protected Product() {
     }
 
     public Long getId() {

--- a/src/main/java/gift/domain/Wish.java
+++ b/src/main/java/gift/domain/Wish.java
@@ -27,7 +27,7 @@ public class Wish {
 
     private int quantity;
 
-    public Wish() {
+    protected Wish() {
     }
 
     public Wish(Long id, Member member, Product product, int quantity) {

--- a/src/main/java/gift/dto/Jwk.java
+++ b/src/main/java/gift/dto/Jwk.java
@@ -1,0 +1,11 @@
+package gift.dto;
+
+public record Jwk(
+        String kid,
+        String kty,
+        String alg,
+        String use,
+        String n,
+        String e
+) {
+}

--- a/src/main/java/gift/dto/JwkSet.java
+++ b/src/main/java/gift/dto/JwkSet.java
@@ -1,0 +1,9 @@
+package gift.dto;
+
+import java.util.List;
+
+public record JwkSet(
+        List<Jwk> keys
+) {
+
+}

--- a/src/main/java/gift/dto/KakaoTextTemplate.java
+++ b/src/main/java/gift/dto/KakaoTextTemplate.java
@@ -1,0 +1,30 @@
+package gift.dto;
+
+public class KakaoTextTemplate {
+
+    private String object_type = "text";
+    private String text;
+    private Link link;
+
+    public KakaoTextTemplate(String text, String url) {
+        this.text = text;
+        this.link = new Link(url, url);
+    }
+
+    public static class Link {
+        private String web_url;
+        private String mobile_web_url;
+
+        public Link(String webUrl, String mobileWebUrl) {
+            this.web_url = webUrl;
+            this.mobile_web_url = mobileWebUrl;
+        }
+
+        public String getWeb_url() { return web_url; }
+        public String getMobile_web_url() { return mobile_web_url; }
+    }
+
+    public String getObject_type() { return object_type; }
+    public String getText() { return text; }
+    public Link getLink() { return link; }
+}

--- a/src/main/java/gift/dto/KakaoTokenResponse.java
+++ b/src/main/java/gift/dto/KakaoTokenResponse.java
@@ -1,8 +1,9 @@
 package gift.dto;
 
 public record KakaoTokenResponse(
-        String accessToken,
+        String access_token,
         String refresh_token,
+        String id_token,
         int expires_in
 ) {
 }

--- a/src/main/java/gift/dto/KakaoTokenResponse.java
+++ b/src/main/java/gift/dto/KakaoTokenResponse.java
@@ -1,0 +1,8 @@
+package gift.dto;
+
+public record KakaoTokenResponse(
+        String accessToken,
+        String refresh_token,
+        int expires_in
+) {
+}

--- a/src/main/java/gift/dto/OrdersRequest.java
+++ b/src/main/java/gift/dto/OrdersRequest.java
@@ -1,0 +1,9 @@
+package gift.dto;
+
+public record OrdersRequest(
+        Long optionId,
+        int quantity,
+        String message
+) {
+
+}

--- a/src/main/java/gift/dto/OrdersRequest.java
+++ b/src/main/java/gift/dto/OrdersRequest.java
@@ -1,7 +1,13 @@
 package gift.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
 public record OrdersRequest(
+        @NotBlank(message = "optionId 값은 필수입니다.")
         Long optionId,
+        @Positive(message = "주문 수량은 0보다 커야합니다.")
+        @NotBlank(message = "주문 수량은 필수입니다.")
         int quantity,
         String message
 ) {

--- a/src/main/java/gift/dto/OrdersResponse.java
+++ b/src/main/java/gift/dto/OrdersResponse.java
@@ -1,0 +1,11 @@
+package gift.dto;
+
+import java.time.LocalDateTime;
+
+public record OrdersResponse(
+        Long id,
+        Long optionId,
+        int quantity,
+        LocalDateTime now,
+        String message) {
+}

--- a/src/main/java/gift/dto/RenewKakaoToken.java
+++ b/src/main/java/gift/dto/RenewKakaoToken.java
@@ -1,0 +1,8 @@
+package gift.dto;
+
+public record RenewKakaoToken(
+        String access_token,
+        int expires_in,
+        String refresh_token
+) {
+}

--- a/src/main/java/gift/repository/KakaoTokenJpaRepository.java
+++ b/src/main/java/gift/repository/KakaoTokenJpaRepository.java
@@ -1,0 +1,10 @@
+package gift.repository;
+
+import gift.domain.KakaoToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KakaoTokenJpaRepository extends JpaRepository<KakaoToken, Long> {
+
+    Optional<KakaoToken> findByMemberId(Long memberId);
+}

--- a/src/main/java/gift/repository/OrdersJpaRepository.java
+++ b/src/main/java/gift/repository/OrdersJpaRepository.java
@@ -1,0 +1,8 @@
+package gift.repository;
+
+import gift.domain.Orders;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrdersJpaRepository extends JpaRepository<Orders, Long> {
+
+}

--- a/src/main/java/gift/repository/ProductJpaRepository.java
+++ b/src/main/java/gift/repository/ProductJpaRepository.java
@@ -1,9 +1,13 @@
 package gift.repository;
 
+import gift.domain.Option;
 import gift.domain.Product;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+
+    List<Product> findByOptions(List<Option> options);
 }

--- a/src/main/java/gift/service/KakaoService.java
+++ b/src/main/java/gift/service/KakaoService.java
@@ -1,25 +1,36 @@
 package gift.service;
 
-import java.util.Map;
+import gift.config.KakaoAuthException;
+import gift.dto.KakaoTokenResponse;
+import java.net.URI;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 public class KakaoService {
 
-    @Value("${kakao.api.key}")
-    private String apiKey;
+    private final String apiKey;
+    private final String redirectUrl;
+    private final RestClient client;
 
-    @Value("${redirect.url}")
-    private String redirectUrl;
+    public KakaoService(
+            @Value("${kakao.api.key}") String apiKey,
+            @Value("${redirect.url}") String redirectUrl, RestClient kakaoRestClient) {
+        this.apiKey = apiKey;
+        this.redirectUrl = redirectUrl;
+        this.client = kakaoRestClient;
+    }
 
-
-    private RestClient client = RestClient.create();
 
     public String getAccessToken(String code) {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
@@ -28,14 +39,28 @@ public class KakaoService {
         body.add("redirect_uri", redirectUrl);
         body.add("code", code);
 
-        Map<String, Object> response = client.post()
-                .uri("https://kauth.kakao.com/oauth/token")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(body)
-                .retrieve()
-                .body(new ParameterizedTypeReference<>() {
-                });
+        try {
+            KakaoTokenResponse response = client.post()
+                    .uri("/oauth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<KakaoTokenResponse>() {
+                    });
+            return response.accessToken();
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            throw new KakaoAuthException("카카오 인증 실패", e, e.getStatusCode());
+        } catch (RestClientException e) {
+            throw new KakaoAuthException("카카오 API 호출 오류", e, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 
-        return response.get("access_token").toString();
+    public URI getOauthUri() {
+        return UriComponentsBuilder.fromUriString("https://kauth.kakao.com")
+                .path("/oauth/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", apiKey)
+                .queryParam("redirect_uri", redirectUrl)
+                .build().toUri();
     }
 }

--- a/src/main/java/gift/service/KakaoService.java
+++ b/src/main/java/gift/service/KakaoService.java
@@ -1,8 +1,15 @@
 package gift.service;
 
+import gift.config.JwtTokenProvider;
 import gift.config.KakaoAuthException;
+import gift.domain.AccountType;
+import gift.domain.KakaoToken;
+import gift.domain.Member;
 import gift.dto.KakaoTokenResponse;
+import gift.repository.KakaoTokenJpaRepository;
+import gift.repository.MemberJpaRepository;
 import java.net.URI;
+import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
@@ -22,13 +29,22 @@ public class KakaoService {
     private final String apiKey;
     private final String redirectUrl;
     private final RestClient client;
+    private final MemberJpaRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final KakaoTokenJpaRepository kakaoTokenRepository;
 
     public KakaoService(
             @Value("${kakao.api.key}") String apiKey,
-            @Value("${redirect.url}") String redirectUrl, RestClient kakaoRestClient) {
+            @Value("${redirect.url}") String redirectUrl,
+            RestClient kakaoRestClient, MemberJpaRepository memberRepository,
+            JwtTokenProvider jwtTokenProvider, KakaoTokenJpaRepository kakaoTokenRepository
+    ) {
         this.apiKey = apiKey;
         this.redirectUrl = redirectUrl;
         this.client = kakaoRestClient;
+        this.memberRepository = memberRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.kakaoTokenRepository = kakaoTokenRepository;
     }
 
 
@@ -41,13 +57,18 @@ public class KakaoService {
 
         try {
             KakaoTokenResponse response = client.post()
-                    .uri("/oauth/token")
+                    .uri("https://kauth.kakao.com/oauth/token")
                     .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                     .body(body)
                     .retrieve()
                     .body(new ParameterizedTypeReference<KakaoTokenResponse>() {
                     });
-            return response.accessToken();
+            String userNickname = jwtTokenProvider.extractNickname(response.id_token());
+            Member member = new Member(null, userNickname, null, null, AccountType.KAKAO);
+            memberRepository.save(member);
+            kakaoTokenRepository.save(new KakaoToken(null, member, response.access_token(), response.refresh_token(), LocalDateTime.now().plusSeconds(response.expires_in())));
+
+            return jwtTokenProvider.createToken(userNickname);
         } catch (HttpClientErrorException | HttpServerErrorException e) {
             throw new KakaoAuthException("카카오 인증 실패", e, e.getStatusCode());
         } catch (RestClientException e) {
@@ -61,6 +82,7 @@ public class KakaoService {
                 .queryParam("response_type", "code")
                 .queryParam("client_id", apiKey)
                 .queryParam("redirect_uri", redirectUrl)
+                .queryParam("scope", "profile_nickname openid")
                 .build().toUri();
     }
 }

--- a/src/main/java/gift/service/KakaoService.java
+++ b/src/main/java/gift/service/KakaoService.java
@@ -51,24 +51,10 @@ public class KakaoService {
 
     @Transactional
     public String getAccessToken(String code) {
-        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("grant_type", "authorization_code");
-        body.add("client_id", apiKey);
-        body.add("redirect_uri", redirectUrl);
-        body.add("code", code);
 
         try {
-            KakaoTokenResponse response = client.post()
-                    .uri("https://kauth.kakao.com/oauth/token")
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .body(body)
-                    .retrieve()
-                    .body(new ParameterizedTypeReference<KakaoTokenResponse>() {
-                    });
-            String userEmail = jwtTokenProvider.extractEmail(response.id_token());
-            if (userEmail == null) {
-                throw new IllegalArgumentException("Email 값을 얻을 수 없습니다.");
-            }
+            KakaoTokenResponse response = requestKakaoToken(code);
+            String userEmail = extractEmailOrThrow(response);
 
             Member member = new Member(null, userEmail, null, null, AccountType.KAKAO);
             memberRepository.save(member);
@@ -80,6 +66,30 @@ public class KakaoService {
         } catch (RestClientException e) {
             throw new KakaoAuthException("카카오 API 호출 오류", e, HttpStatus.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    private KakaoTokenResponse requestKakaoToken(String code) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", apiKey);
+        body.add("redirect_uri", redirectUrl);
+        body.add("code", code);
+        KakaoTokenResponse response = client.post()
+                .uri("https://kauth.kakao.com/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .body(new ParameterizedTypeReference<KakaoTokenResponse>() {
+                });
+        return response;
+    }
+
+    private String extractEmailOrThrow(KakaoTokenResponse response) {
+        String userEmail = jwtTokenProvider.extractEmail(response.id_token());
+        if (userEmail == null) {
+            throw new IllegalArgumentException("Email 값을 얻을 수 없습니다.");
+        }
+        return userEmail;
     }
 
     public URI getOauthUri() {

--- a/src/main/java/gift/service/KakaoService.java
+++ b/src/main/java/gift/service/KakaoService.java
@@ -8,6 +8,7 @@ import gift.domain.Member;
 import gift.dto.KakaoTokenResponse;
 import gift.repository.KakaoTokenJpaRepository;
 import gift.repository.MemberJpaRepository;
+import gift.util.AesUtil;
 import java.net.URI;
 import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +31,7 @@ public class KakaoService {
     private final String apiKey;
     private final String redirectUrl;
     private final RestClient client;
+    private final AesUtil aesUtil;
     private final MemberJpaRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoTokenJpaRepository kakaoTokenRepository;
@@ -37,12 +39,13 @@ public class KakaoService {
     public KakaoService(
             @Value("${kakao.api.key}") String apiKey,
             @Value("${redirect.url}") String redirectUrl,
-            RestClient kakaoRestClient, MemberJpaRepository memberRepository,
+            RestClient kakaoRestClient, AesUtil aesUtil, MemberJpaRepository memberRepository,
             JwtTokenProvider jwtTokenProvider, KakaoTokenJpaRepository kakaoTokenRepository
     ) {
         this.apiKey = apiKey;
         this.redirectUrl = redirectUrl;
         this.client = kakaoRestClient;
+        this.aesUtil = aesUtil;
         this.memberRepository = memberRepository;
         this.jwtTokenProvider = jwtTokenProvider;
         this.kakaoTokenRepository = kakaoTokenRepository;
@@ -58,7 +61,7 @@ public class KakaoService {
 
             Member member = new Member(null, userEmail, null, null, AccountType.KAKAO);
             memberRepository.save(member);
-            kakaoTokenRepository.save(new KakaoToken(null, member, response.access_token(), response.refresh_token(), LocalDateTime.now().plusSeconds(response.expires_in())));
+            kakaoTokenRepository.save(new KakaoToken(null, member, aesUtil.encrypt(response.access_token()), aesUtil.encrypt(response.refresh_token()), LocalDateTime.now().plusSeconds(response.expires_in())));
 
             return jwtTokenProvider.createToken(userEmail);
         } catch (HttpClientErrorException | HttpServerErrorException e) {

--- a/src/main/java/gift/service/KakaoService.java
+++ b/src/main/java/gift/service/KakaoService.java
@@ -15,6 +15,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
@@ -48,6 +49,7 @@ public class KakaoService {
     }
 
 
+    @Transactional
     public String getAccessToken(String code) {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
@@ -63,12 +65,16 @@ public class KakaoService {
                     .retrieve()
                     .body(new ParameterizedTypeReference<KakaoTokenResponse>() {
                     });
-            String userNickname = jwtTokenProvider.extractNickname(response.id_token());
-            Member member = new Member(null, userNickname, null, null, AccountType.KAKAO);
+            String userEmail = jwtTokenProvider.extractEmail(response.id_token());
+            if (userEmail == null) {
+                throw new IllegalArgumentException("Email 값을 얻을 수 없습니다.");
+            }
+
+            Member member = new Member(null, userEmail, null, null, AccountType.KAKAO);
             memberRepository.save(member);
             kakaoTokenRepository.save(new KakaoToken(null, member, response.access_token(), response.refresh_token(), LocalDateTime.now().plusSeconds(response.expires_in())));
 
-            return jwtTokenProvider.createToken(userNickname);
+            return jwtTokenProvider.createToken(userEmail);
         } catch (HttpClientErrorException | HttpServerErrorException e) {
             throw new KakaoAuthException("카카오 인증 실패", e, e.getStatusCode());
         } catch (RestClientException e) {
@@ -82,7 +88,7 @@ public class KakaoService {
                 .queryParam("response_type", "code")
                 .queryParam("client_id", apiKey)
                 .queryParam("redirect_uri", redirectUrl)
-                .queryParam("scope", "profile_nickname openid")
+                .queryParam("scope", "account_email openid")
                 .build().toUri();
     }
 }

--- a/src/main/java/gift/service/KakaoService.java
+++ b/src/main/java/gift/service/KakaoService.java
@@ -1,11 +1,15 @@
 package gift.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gift.config.JwtTokenProvider;
 import gift.config.KakaoAuthException;
 import gift.domain.AccountType;
 import gift.domain.KakaoToken;
 import gift.domain.Member;
+import gift.dto.KakaoTextTemplate;
 import gift.dto.KakaoTokenResponse;
+import gift.dto.RenewKakaoToken;
 import gift.repository.KakaoTokenJpaRepository;
 import gift.repository.MemberJpaRepository;
 import gift.util.AesUtil;
@@ -39,8 +43,11 @@ public class KakaoService {
     public KakaoService(
             @Value("${kakao.api.key}") String apiKey,
             @Value("${redirect.url}") String redirectUrl,
-            RestClient kakaoRestClient, AesUtil aesUtil, MemberJpaRepository memberRepository,
-            JwtTokenProvider jwtTokenProvider, KakaoTokenJpaRepository kakaoTokenRepository
+            RestClient kakaoRestClient,
+            AesUtil aesUtil,
+            MemberJpaRepository memberRepository,
+            JwtTokenProvider jwtTokenProvider,
+            KakaoTokenJpaRepository kakaoTokenRepository
     ) {
         this.apiKey = apiKey;
         this.redirectUrl = redirectUrl;
@@ -58,6 +65,12 @@ public class KakaoService {
         try {
             KakaoTokenResponse response = requestKakaoToken(code);
             String userEmail = extractEmailOrThrow(response);
+
+            if (memberRepository.findByEmail(userEmail).isPresent()) {
+                Member member = memberRepository.findByEmail(userEmail).get();
+                renewKakaToken(kakaoTokenRepository.findByMemberId(member.getId()).get());
+                return jwtTokenProvider.createToken(userEmail);
+            }
 
             Member member = new Member(null, userEmail, null, null, AccountType.KAKAO);
             memberRepository.save(member);
@@ -93,6 +106,52 @@ public class KakaoService {
             throw new IllegalArgumentException("Email 값을 얻을 수 없습니다.");
         }
         return userEmail;
+    }
+
+    public void renewKakaToken(KakaoToken kakaoToken) {
+        if (kakaoToken.isExpired()) {
+
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("grant_type", "refresh_token");
+            body.add("client_id", apiKey);
+            body.add("redirect_uri", kakaoToken.getRefreshToken());
+
+            RenewKakaoToken renewKakaoToken = client.post()
+                    .uri("https://kauth.kakao.com/oauth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<RenewKakaoToken>() {
+                    });
+
+            if (renewKakaoToken.access_token() != null && renewKakaoToken.refresh_token() != null ) {
+                kakaoToken.renewAccessToken(aesUtil.encrypt(renewKakaoToken.access_token()), LocalDateTime.now().plusSeconds(renewKakaoToken.expires_in()));
+                kakaoToken.renewRefreshToken(aesUtil.encrypt(renewKakaoToken.refresh_token()));
+            }
+        }
+    }
+
+    public void sendMessageToMe(String message, String accessToken) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        KakaoTextTemplate template = new KakaoTextTemplate(message, "kakao.com");
+        String templateJson;
+
+        try {
+            templateJson = objectMapper.writeValueAsString(template);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("JSON 직렬화 실패", e);
+        }
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("template_object", templateJson);
+
+        client.post()
+                .uri("https://kapi.kakao.com/v2/api/talk/memo/default/send")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .toBodilessEntity();
     }
 
     public URI getOauthUri() {

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -1,6 +1,7 @@
 package gift.service;
 
 import gift.config.NotMatchPasswordException;
+import gift.domain.AccountType;
 import gift.domain.Member;
 import gift.dto.CreateMemberRequest;
 import gift.dto.CreateMemberResponse;
@@ -29,7 +30,7 @@ public class MemberService {
         duplicateEmailCheck(request.email());
         String salt = ShaUtil.getSalt();
         String encryptPassword = ShaUtil.encrypt(request.password(), salt);
-        Member member = memberRepository.save(new Member(null, request.email(), encryptPassword, salt));
+        Member member = memberRepository.save(new Member(null, request.email(), encryptPassword, salt, AccountType.LOCAL));
         return new CreateMemberResponse(member.getId(), member.getEmail());
     }
 

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -15,6 +15,7 @@ import gift.repository.OptionJpaRepository;
 import gift.repository.OrdersJpaRepository;
 import gift.repository.ProductJpaRepository;
 import gift.repository.WishJpaRepository;
+import gift.util.AesUtil;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -36,18 +37,21 @@ public class OrderService {
     private final WishJpaRepository wishRepository;
     private final KakaoTokenJpaRepository kakaoTokenRepository;
     private final OrdersJpaRepository ordersRepository;
+    private final AesUtil aesUtil;
     private final RestClient client;
     private final String apiKey;
 
 
     public OrderService(OptionJpaRepository optionRepository,
             ProductJpaRepository productRepository, WishJpaRepository wishRepository,
-            KakaoTokenJpaRepository kakaoTokenRepository, OrdersJpaRepository ordersRepository, RestClient client, @Value("${kakao.api.key}") String apiKey) {
+            KakaoTokenJpaRepository kakaoTokenRepository, OrdersJpaRepository ordersRepository,
+            AesUtil aesUtil, RestClient client, @Value("${kakao.api.key}") String apiKey) {
         this.optionRepository = optionRepository;
         this.productRepository = productRepository;
         this.wishRepository = wishRepository;
         this.kakaoTokenRepository = kakaoTokenRepository;
         this.ordersRepository = ordersRepository;
+        this.aesUtil = aesUtil;
         this.apiKey = apiKey;
         this.client = client;
     }
@@ -67,7 +71,7 @@ public class OrderService {
                 .orElseThrow(() -> new NoSuchElementException("조회할 수 없는 토큰입니다"));
 
         renewKakaToken(kakaoToken);
-        String accessToken = kakaoToken.getAccessToken();
+        String accessToken = aesUtil.decrypt(kakaoToken.getAccessToken());
         sendMessageToMe(message, accessToken);
 
         Orders savedOrder = ordersRepository.save(new Orders(null, message, quantity, option));
@@ -77,9 +81,7 @@ public class OrderService {
 
     private void sendMessageToMe(String message, String accessToken) {
         ObjectMapper objectMapper = new ObjectMapper();
-
         KakaoTextTemplate template = new KakaoTextTemplate(message, "kakao.com");
-
         String templateJson;
 
         try {
@@ -116,9 +118,9 @@ public class OrderService {
                     .body(new ParameterizedTypeReference<RenewKakaoToken>() {
                     });
 
-            kakaoToken.renewAccessToken(renewKakaoToken.access_token());
-            if (renewKakaoToken.refresh_token() != null) {
-                kakaoToken.renewRefreshToken(renewKakaoToken.refresh_token());
+            if (renewKakaoToken.access_token() != null && renewKakaoToken.refresh_token() != null ) {
+                kakaoToken.renewAccessToken(aesUtil.encrypt(renewKakaoToken.access_token()));
+                kakaoToken.renewRefreshToken(aesUtil.encrypt(renewKakaoToken.refresh_token()));
                 kakaoToken.renewAccessTokenExpiresAt(LocalDateTime.now().plusSeconds(renewKakaoToken.expires_in()));
             }
         }

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
@@ -51,6 +52,7 @@ public class OrderService {
         this.client = client;
     }
 
+    @Transactional
     public OrdersResponse createOrder(Long memberId, Long optionId, int quantity, String message) {
         Option option = optionRepository.findById(optionId)
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 상품입니다."));

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -1,15 +1,12 @@
 package gift.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import gift.domain.KakaoToken;
 import gift.domain.Option;
 import gift.domain.Orders;
 import gift.domain.Product;
 import gift.domain.Wish;
-import gift.dto.KakaoTextTemplate;
+import gift.dto.OrdersRequest;
 import gift.dto.OrdersResponse;
-import gift.dto.RenewKakaoToken;
 import gift.repository.KakaoTokenJpaRepository;
 import gift.repository.OptionJpaRepository;
 import gift.repository.OrdersJpaRepository;
@@ -20,14 +17,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClient;
 
 @Service
 public class OrderService {
@@ -37,30 +28,29 @@ public class OrderService {
     private final WishJpaRepository wishRepository;
     private final KakaoTokenJpaRepository kakaoTokenRepository;
     private final OrdersJpaRepository ordersRepository;
+    private final KakaoService kakaoService;
     private final AesUtil aesUtil;
-    private final RestClient client;
-    private final String apiKey;
 
 
     public OrderService(OptionJpaRepository optionRepository,
             ProductJpaRepository productRepository, WishJpaRepository wishRepository,
             KakaoTokenJpaRepository kakaoTokenRepository, OrdersJpaRepository ordersRepository,
-            AesUtil aesUtil, RestClient client, @Value("${kakao.api.key}") String apiKey) {
+            KakaoService kakaoService,
+            AesUtil aesUtil) {
         this.optionRepository = optionRepository;
         this.productRepository = productRepository;
         this.wishRepository = wishRepository;
         this.kakaoTokenRepository = kakaoTokenRepository;
         this.ordersRepository = ordersRepository;
+        this.kakaoService = kakaoService;
         this.aesUtil = aesUtil;
-        this.apiKey = apiKey;
-        this.client = client;
     }
 
     @Transactional
-    public OrdersResponse createOrder(Long memberId, Long optionId, int quantity, String message) {
-        Option option = optionRepository.findById(optionId)
+    public OrdersResponse createOrder(Long memberId, OrdersRequest request) {
+        Option option = optionRepository.findById(request.optionId())
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 상품입니다."));
-        option.subtractQuantity(quantity);
+        option.subtractQuantity(request.quantity());
 
         List<Product> productList = productRepository.findByOptions(List.of(option));
         for (Product product : productList) {
@@ -70,65 +60,12 @@ public class OrderService {
         KakaoToken kakaoToken = kakaoTokenRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new NoSuchElementException("조회할 수 없는 토큰입니다"));
 
-        renewKakaToken(kakaoToken);
+        kakaoService.renewKakaToken(kakaoToken);
         String accessToken = aesUtil.decrypt(kakaoToken.getAccessToken());
-        sendMessageToMe(message, accessToken);
+        kakaoService.sendMessageToMe(request.message(), accessToken);
 
-        Orders savedOrder = ordersRepository.save(new Orders(null, message, quantity, option));
+        Orders savedOrder = ordersRepository.save(new Orders(null, request.message(), request.quantity(), option));
 
-        return new OrdersResponse(savedOrder.getId(), optionId, quantity, LocalDateTime.now(), message);
+        return new OrdersResponse(savedOrder.getId(), request.optionId(), request.quantity(), LocalDateTime.now(), request.message());
     }
-
-    private void sendMessageToMe(String message, String accessToken) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        KakaoTextTemplate template = new KakaoTextTemplate(message, "kakao.com");
-        String templateJson;
-
-        try {
-            templateJson = objectMapper.writeValueAsString(template);
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("JSON 직렬화 실패", e);
-        }
-
-        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("template_object", templateJson);
-
-        client.post()
-                .uri("https://kapi.kakao.com/v2/api/talk/memo/default/send")
-                .header("Authorization", "Bearer " + accessToken)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(body)
-                .retrieve()
-                .toBodilessEntity();
-    }
-
-    private void renewKakaToken(KakaoToken kakaoToken) {
-        if (isExpired(kakaoToken)) {
-
-            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-            body.add("grant_type", "refresh_token");
-            body.add("client_id", apiKey);
-            body.add("redirect_uri", kakaoToken.getRefreshToken());
-
-            RenewKakaoToken renewKakaoToken = client.post()
-                    .uri("https://kauth.kakao.com/oauth/token")
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .body(body)
-                    .retrieve()
-                    .body(new ParameterizedTypeReference<RenewKakaoToken>() {
-                    });
-
-            if (renewKakaoToken.access_token() != null && renewKakaoToken.refresh_token() != null ) {
-                kakaoToken.renewAccessToken(aesUtil.encrypt(renewKakaoToken.access_token()));
-                kakaoToken.renewRefreshToken(aesUtil.encrypt(renewKakaoToken.refresh_token()));
-                kakaoToken.renewAccessTokenExpiresAt(LocalDateTime.now().plusSeconds(renewKakaoToken.expires_in()));
-            }
-        }
-    }
-
-    private static boolean isExpired(KakaoToken kakaoToken) {
-        return LocalDateTime.now().isAfter(kakaoToken.getAccessTokenExpiresAt());
-    }
-
-
 }

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -1,0 +1,130 @@
+package gift.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.domain.KakaoToken;
+import gift.domain.Option;
+import gift.domain.Orders;
+import gift.domain.Product;
+import gift.domain.Wish;
+import gift.dto.KakaoTextTemplate;
+import gift.dto.OrdersResponse;
+import gift.dto.RenewKakaoToken;
+import gift.repository.KakaoTokenJpaRepository;
+import gift.repository.OptionJpaRepository;
+import gift.repository.OrdersJpaRepository;
+import gift.repository.ProductJpaRepository;
+import gift.repository.WishJpaRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class OrderService {
+
+    private final OptionJpaRepository optionRepository;
+    private final ProductJpaRepository productRepository;
+    private final WishJpaRepository wishRepository;
+    private final KakaoTokenJpaRepository kakaoTokenRepository;
+    private final OrdersJpaRepository ordersRepository;
+    private final RestClient client;
+    private final String apiKey;
+
+
+    public OrderService(OptionJpaRepository optionRepository,
+            ProductJpaRepository productRepository, WishJpaRepository wishRepository,
+            KakaoTokenJpaRepository kakaoTokenRepository, OrdersJpaRepository ordersRepository, RestClient client, @Value("${kakao.api.key}") String apiKey) {
+        this.optionRepository = optionRepository;
+        this.productRepository = productRepository;
+        this.wishRepository = wishRepository;
+        this.kakaoTokenRepository = kakaoTokenRepository;
+        this.ordersRepository = ordersRepository;
+        this.apiKey = apiKey;
+        this.client = client;
+    }
+
+    public OrdersResponse createOrder(Long memberId, Long optionId, int quantity, String message) {
+        Option option = optionRepository.findById(optionId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 상품입니다."));
+        option.subtractQuantity(quantity);
+
+        List<Product> productList = productRepository.findByOptions(List.of(option));
+        for (Product product : productList) {
+            Optional<Wish> wishByProduct = wishRepository.findByMemberIdAndProductId(memberId,product.getId());
+            wishByProduct.ifPresent(wishRepository::delete);
+        }
+        KakaoToken kakaoToken = kakaoTokenRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NoSuchElementException("조회할 수 없는 토큰입니다"));
+
+        renewKakaToken(kakaoToken);
+        String accessToken = kakaoToken.getAccessToken();
+        sendMessageToMe(message, accessToken);
+
+        Orders savedOrder = ordersRepository.save(new Orders(null, message, quantity, option));
+
+        return new OrdersResponse(savedOrder.getId(), optionId, quantity, LocalDateTime.now(), message);
+    }
+
+    private void sendMessageToMe(String message, String accessToken) {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        KakaoTextTemplate template = new KakaoTextTemplate(message, "kakao.com");
+
+        String templateJson;
+
+        try {
+            templateJson = objectMapper.writeValueAsString(template);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("JSON 직렬화 실패", e);
+        }
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("template_object", templateJson);
+
+        client.post()
+                .uri("https://kapi.kakao.com/v2/api/talk/memo/default/send")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    private void renewKakaToken(KakaoToken kakaoToken) {
+        if (isExpired(kakaoToken)) {
+
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("grant_type", "refresh_token");
+            body.add("client_id", apiKey);
+            body.add("redirect_uri", kakaoToken.getRefreshToken());
+
+            RenewKakaoToken renewKakaoToken = client.post()
+                    .uri("https://kauth.kakao.com/oauth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<RenewKakaoToken>() {
+                    });
+
+            kakaoToken.renewAccessToken(renewKakaoToken.access_token());
+            if (renewKakaoToken.refresh_token() != null) {
+                kakaoToken.renewRefreshToken(renewKakaoToken.refresh_token());
+                kakaoToken.renewAccessTokenExpiresAt(LocalDateTime.now().plusSeconds(renewKakaoToken.expires_in()));
+            }
+        }
+    }
+
+    private static boolean isExpired(KakaoToken kakaoToken) {
+        return LocalDateTime.now().isAfter(kakaoToken.getAccessTokenExpiresAt());
+    }
+
+
+}

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -23,12 +23,12 @@ public class ProductService {
     }
 
     public CreateProductResponse save(CreateProductRequest request) {
-        Product product = repository.save(
-                new Product(null, request.name(), request.price(), request.imageUrl()));
+        Product product = new Product(null, request.name(), request.price(), request.imageUrl());
         List<Option> options = request.options().stream()
                 .map(o -> new Option(null, o.name(), o.quantity(), product)).toList();
 
         options.forEach(product::addOption);
+        repository.save(product);
 
         return new CreateProductResponse(product.getId(), product.getName(), product.getPrice(), product.getImageUrl());
     }

--- a/src/main/java/gift/util/AesUtil.java
+++ b/src/main/java/gift/util/AesUtil.java
@@ -1,0 +1,42 @@
+package gift.util;
+
+import gift.config.AesException;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AesUtil {
+
+    private static final String ALGORITHM = "AES";
+    @Value("${aes.secret.key}")
+    private String SECRET_KEY ;
+
+    public String encrypt(String plainText) {
+        try {
+            SecretKeySpec key = new SecretKeySpec(SECRET_KEY.getBytes(), ALGORITHM);
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, key);
+            byte[] encrypted = cipher.doFinal(plainText.getBytes());
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            throw new AesException("암호화 실패", e);
+        }
+    }
+
+    public String decrypt(String encryptedText)  {
+        try {
+            SecretKeySpec key = new SecretKeySpec(SECRET_KEY.getBytes(), ALGORITHM);
+            Cipher cipher = null;
+            cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, key);
+            byte[] decrypted = cipher.doFinal(Base64.getDecoder().decode(encryptedText));
+            return new String(decrypted);
+        } catch (Exception e) {
+            throw new AesException("복호화 실패", e);
+
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,4 @@ logging.level.org.hibernate.orm.jdbc.bind=TRACE
 
 kakao.api.key=${KAKAO_API_KEY}
 redirect.url=${REDIRECT_URL}
+aes.secret.key=${AES_SECRET_KEY}

--- a/src/test/java/gift/controller/WishRestControllerTest.java
+++ b/src/test/java/gift/controller/WishRestControllerTest.java
@@ -13,26 +13,37 @@ import gift.dto.CreateWishResponse;
 import gift.dto.LoginMemberRequest;
 import gift.dto.LoginMemberResponse;
 import gift.dto.UpdateWishRequest;
+import gift.repository.MemberJpaRepository;
+import gift.repository.WishJpaRepository;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
-@Sql(statements = "delete from wish")
-@Sql(statements = "delete from member")
-@Sql(statements = "delete from product")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class WishRestControllerTest {
+
+    @Autowired
+    private MemberJpaRepository memberRepository;
+    @Autowired
+    private WishJpaRepository wishRepository;
 
     @LocalServerPort
     private int port;
     private RestClient client = RestClient.create();
+
+    @BeforeEach
+    void celar() {
+        wishRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("로그인 멤버 상품 조회")

--- a/src/test/java/gift/service/KakaoServiceTest.java
+++ b/src/test/java/gift/service/KakaoServiceTest.java
@@ -7,8 +7,15 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import gift.config.JwtTokenProvider;
 import gift.config.KakaoAuthException;
+import gift.domain.KakaoToken;
+import gift.domain.Member;
 import gift.dto.KakaoTokenResponse;
+import gift.repository.KakaoTokenJpaRepository;
+import gift.repository.MemberJpaRepository;
+import java.time.LocalDateTime;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,18 +34,24 @@ class KakaoServiceTest {
 
     @Mock
     private RestClient mockRestClient;
+    @Mock
+    private MemberJpaRepository memberRepository;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private KakaoTokenJpaRepository kakaoTokenRepository;
 
     @InjectMocks
     private KakaoService kakaoService;
 
     @BeforeEach
     void setUp() {
-        kakaoService = new KakaoService("dummyKey", "dummyUrl", mockRestClient);
+        kakaoService = new KakaoService("dummyKey", "dummyUrl", mockRestClient, memberRepository, jwtTokenProvider, kakaoTokenRepository);
     }
 
 
     @Test
-    void 엑세스_토큰_정상_획득() {
+    void jwt_토큰_정상_획득() {
         // given
         String code = "dummyCode";
 
@@ -46,8 +59,11 @@ class KakaoServiceTest {
         RestClient.RequestBodySpec bodySpec = mock(RestClient.RequestBodySpec.class);
         RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
 
-        KakaoTokenResponse fakeResponse = new KakaoTokenResponse("mockToken", "refreshToken", 200);
+        KakaoTokenResponse fakeResponse = new KakaoTokenResponse("mockToken", "refreshToken", "null", 200);
+        Member member = new Member(1L, "email", null, null);
+        KakaoToken kakaoToken = new KakaoToken(1L, member, "mockToken", "refreshToken", LocalDateTime.now().plusSeconds(200));
 
+        // when
         when(mockRestClient.post()).thenReturn(uriSpec);
         when(uriSpec.uri(anyString())).thenReturn(bodySpec);
         when(bodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED)).thenReturn(bodySpec);
@@ -55,16 +71,20 @@ class KakaoServiceTest {
         when(bodySpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(any(ParameterizedTypeReference.class))).thenReturn(fakeResponse);
 
+        when(memberRepository.save(any())).thenReturn(member);
+        when(kakaoTokenRepository.save(any())).thenReturn(kakaoToken);
 
-        // when
+        when(jwtTokenProvider.extractEmail(fakeResponse.id_token())).thenReturn("email");
+        when(jwtTokenProvider.createToken("email")).thenReturn("jwtToken");
+
         String result = kakaoService.getAccessToken(code);
 
         // then
-        assertEquals("mockToken", result);
+        assertEquals("jwtToken", result);
     }
 
     @Test
-    void 엑세스_토큰_획득_실패() {
+    void 엑세스_토큰_획득_실패_인가_코드_불일치() {
         // given
         String code = "dummyCode";
 
@@ -72,8 +92,7 @@ class KakaoServiceTest {
         RestClient.RequestBodySpec bodySpec = mock(RestClient.RequestBodySpec.class);
         RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
 
-        KakaoTokenResponse fakeResponse = new KakaoTokenResponse("mockToken", "refreshToken", 200);
-
+        //when
         when(mockRestClient.post()).thenReturn(uriSpec);
         when(uriSpec.uri(anyString())).thenReturn(bodySpec);
         when(bodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED)).thenReturn(bodySpec);
@@ -82,11 +101,39 @@ class KakaoServiceTest {
         when(responseSpec.body(any(ParameterizedTypeReference.class)))
                 .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED, "Unauthorized"));
 
-        // when & then
+        //then
         KakaoAuthException exception = assertThrows(KakaoAuthException.class, () ->
-                kakaoService.getAccessToken(code));
+                kakaoService.getAccessToken("notMatchCode"));
 
         assertEquals("카카오 인증 실패", exception.getMessage());
         assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
     }
+
+    @Test
+    void 엑세스_토큰_획득_실패_email_추출_실패() {
+        // given
+        String code = "dummyCode";
+
+        RestClient.RequestBodyUriSpec uriSpec = mock(RestClient.RequestBodyUriSpec.class);
+        RestClient.RequestBodySpec bodySpec = mock(RestClient.RequestBodySpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        KakaoTokenResponse fakeResponse = new KakaoTokenResponse("mockToken", "refreshToken", "null", 200);
+        Member member = new Member(1L, "email", null, null);
+        KakaoToken kakaoToken = new KakaoToken(1L, member, "mockToken", "refreshToken", LocalDateTime.now().plusSeconds(200));
+
+        // when
+        when(mockRestClient.post()).thenReturn(uriSpec);
+        when(uriSpec.uri(anyString())).thenReturn(bodySpec);
+        when(bodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED)).thenReturn(bodySpec);
+        when(bodySpec.body(any(MultiValueMap.class))).thenReturn(bodySpec);
+        when(bodySpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(ParameterizedTypeReference.class))).thenReturn(fakeResponse);
+        when(jwtTokenProvider.extractEmail(fakeResponse.id_token())).thenThrow(new IllegalArgumentException());
+
+        // then
+        Assertions.assertThatIllegalArgumentException().isThrownBy(() -> kakaoService.getAccessToken(code));
+    }
+
+
 }

--- a/src/test/java/gift/service/KakaoServiceTest.java
+++ b/src/test/java/gift/service/KakaoServiceTest.java
@@ -1,0 +1,92 @@
+package gift.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import gift.config.KakaoAuthException;
+import gift.dto.KakaoTokenResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoServiceTest {
+
+    @Mock
+    private RestClient mockRestClient;
+
+    @InjectMocks
+    private KakaoService kakaoService;
+
+    @BeforeEach
+    void setUp() {
+        kakaoService = new KakaoService("dummyKey", "dummyUrl", mockRestClient);
+    }
+
+
+    @Test
+    void 엑세스_토큰_정상_획득() {
+        // given
+        String code = "dummyCode";
+
+        RestClient.RequestBodyUriSpec uriSpec = mock(RestClient.RequestBodyUriSpec.class);
+        RestClient.RequestBodySpec bodySpec = mock(RestClient.RequestBodySpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        KakaoTokenResponse fakeResponse = new KakaoTokenResponse("mockToken", "refreshToken", 200);
+
+        when(mockRestClient.post()).thenReturn(uriSpec);
+        when(uriSpec.uri(anyString())).thenReturn(bodySpec);
+        when(bodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED)).thenReturn(bodySpec);
+        when(bodySpec.body(any(MultiValueMap.class))).thenReturn(bodySpec);
+        when(bodySpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(ParameterizedTypeReference.class))).thenReturn(fakeResponse);
+
+
+        // when
+        String result = kakaoService.getAccessToken(code);
+
+        // then
+        assertEquals("mockToken", result);
+    }
+
+    @Test
+    void 엑세스_토큰_획득_실패() {
+        // given
+        String code = "dummyCode";
+
+        RestClient.RequestBodyUriSpec uriSpec = mock(RestClient.RequestBodyUriSpec.class);
+        RestClient.RequestBodySpec bodySpec = mock(RestClient.RequestBodySpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        KakaoTokenResponse fakeResponse = new KakaoTokenResponse("mockToken", "refreshToken", 200);
+
+        when(mockRestClient.post()).thenReturn(uriSpec);
+        when(uriSpec.uri(anyString())).thenReturn(bodySpec);
+        when(bodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED)).thenReturn(bodySpec);
+        when(bodySpec.body(any(MultiValueMap.class))).thenReturn(bodySpec);
+        when(bodySpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(any(ParameterizedTypeReference.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED, "Unauthorized"));
+
+        // when & then
+        KakaoAuthException exception = assertThrows(KakaoAuthException.class, () ->
+                kakaoService.getAccessToken(code));
+
+        assertEquals("카카오 인증 실패", exception.getMessage());
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getHttpStatus());
+    }
+}

--- a/src/test/java/gift/service/KakaoServiceTest.java
+++ b/src/test/java/gift/service/KakaoServiceTest.java
@@ -14,6 +14,7 @@ import gift.domain.Member;
 import gift.dto.KakaoTokenResponse;
 import gift.repository.KakaoTokenJpaRepository;
 import gift.repository.MemberJpaRepository;
+import gift.util.AesUtil;
 import java.time.LocalDateTime;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,13 +41,15 @@ class KakaoServiceTest {
     private JwtTokenProvider jwtTokenProvider;
     @Mock
     private KakaoTokenJpaRepository kakaoTokenRepository;
+    @Mock
+    private AesUtil aesUtil;
 
     @InjectMocks
     private KakaoService kakaoService;
 
     @BeforeEach
     void setUp() {
-        kakaoService = new KakaoService("dummyKey", "dummyUrl", mockRestClient, memberRepository, jwtTokenProvider, kakaoTokenRepository);
+        kakaoService = new KakaoService("dummyKey", "dummyUrl", mockRestClient,aesUtil, memberRepository, jwtTokenProvider, kakaoTokenRepository);
     }
 
 

--- a/src/test/java/gift/service/OrderServiceTest.java
+++ b/src/test/java/gift/service/OrderServiceTest.java
@@ -1,0 +1,124 @@
+package gift.service;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import gift.domain.AccountType;
+import gift.domain.KakaoToken;
+import gift.domain.Member;
+import gift.domain.Option;
+import gift.domain.Orders;
+import gift.domain.Product;
+import gift.domain.Wish;
+import gift.dto.OrdersRequest;
+import gift.dto.OrdersResponse;
+import gift.repository.KakaoTokenJpaRepository;
+import gift.repository.OptionJpaRepository;
+import gift.repository.OrdersJpaRepository;
+import gift.repository.ProductJpaRepository;
+import gift.repository.WishJpaRepository;
+import gift.util.AesUtil;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OptionJpaRepository optionRepository;
+    @Mock
+    private ProductJpaRepository productRepository;
+    @Mock
+    private WishJpaRepository wishRepository;
+    @Mock
+    private KakaoTokenJpaRepository kakaoTokenRepository;
+    @Mock
+    private KakaoService kakaoService;
+    @Mock
+    private AesUtil aesUtil;
+    @Mock
+    private OrdersJpaRepository ordersRepository;
+    @InjectMocks
+    OrderService orderService;
+
+    @BeforeEach
+    void setUp() {
+        orderService = new OrderService(optionRepository, productRepository, wishRepository, kakaoTokenRepository, ordersRepository, kakaoService, aesUtil);
+    }
+
+
+    @Test
+    void 주문_등록_성공() {
+        Product product = new Product(1L, "productName", 1000, "url");
+        Option option = new Option(1L, "optionName", 10, product);
+        Member member = new Member(1L, "email", null, null, AccountType.KAKAO);
+        Wish wish = new Wish(1L, member, product, 1);
+        KakaoToken kakaoToken = new KakaoToken(1L, member, "accessToken", "refreshToken", LocalDateTime.now());
+        Orders savedOrder = new Orders(1L, "message", 1, option);
+        OrdersRequest ordersRequest = new OrdersRequest(option.getId(), savedOrder.getQuantity(), savedOrder.getMessage());
+
+        when(optionRepository.findById(option.getId())).thenReturn(Optional.of(option));
+        when(productRepository.findByOptions(List.of(option))).thenReturn(List.of(product));
+        when(wishRepository.findByMemberIdAndProductId(member.getId(), product.getId())).thenReturn(Optional.of(wish));
+        when(kakaoTokenRepository.findByMemberId(member.getId())).thenReturn(Optional.of(kakaoToken));
+        when(aesUtil.decrypt(any())).thenReturn("decryptToken");
+        when(ordersRepository.save(any())).thenReturn(savedOrder);
+
+        //when
+        OrdersResponse response = orderService.createOrder(member.getId(), ordersRequest);
+
+        //then
+        assertEquals(savedOrder.getId(), response.id());
+        assertEquals(option.getId(), response.optionId());
+        assertEquals(ordersRequest.quantity(), response.quantity());
+        assertEquals(ordersRequest.message(), response.message());
+    }
+
+    @Test
+    void 주문_등록_옵션_조회_실패() {
+        Product product = new Product(1L, "productName", 1000, "url");
+        Option option = new Option(1L, "optionName", 10, product);
+        Member member = new Member(1L, "email", null, null, AccountType.KAKAO);
+        Wish wish = new Wish(1L, member, product, 1);
+        KakaoToken kakaoToken = new KakaoToken(1L, member, "accessToken", "refreshToken", LocalDateTime.now());
+        Orders savedOrder = new Orders(1L, "message", 1, option);
+        OrdersRequest ordersRequest = new OrdersRequest(option.getId(), savedOrder.getQuantity(), savedOrder.getMessage());
+
+        when(optionRepository.findById(option.getId())).thenThrow(new IllegalArgumentException());
+
+        //then
+        assertThatIllegalArgumentException().isThrownBy(() -> orderService.createOrder(member.getId(), ordersRequest));
+    }
+
+
+    @Test
+    void 주문_등록_토큰_조회_실패() {
+        Product product = new Product(1L, "productName", 1000, "url");
+        Option option = new Option(1L, "optionName", 10, product);
+        Member member = new Member(1L, "email", null, null, AccountType.KAKAO);
+        Wish wish = new Wish(1L, member, product, 1);
+        KakaoToken kakaoToken = new KakaoToken(1L, member, "accessToken", "refreshToken", LocalDateTime.now());
+        Orders savedOrder = new Orders(1L, "message", 1, option);
+        OrdersRequest ordersRequest = new OrdersRequest(option.getId(), savedOrder.getQuantity(), savedOrder.getMessage());
+
+        when(optionRepository.findById(option.getId())).thenReturn(Optional.of(option));
+        when(productRepository.findByOptions(List.of(option))).thenReturn(List.of(product));
+        when(wishRepository.findByMemberIdAndProductId(member.getId(), product.getId())).thenReturn(Optional.of(wish));
+        when(kakaoTokenRepository.findByMemberId(member.getId())).thenThrow(new NoSuchElementException());
+
+        //then
+        assertThatThrownBy(() -> orderService.createOrder(member.getId(), ordersRequest));
+    }
+
+}


### PR DESCRIPTION
멘토님 안녕하세요 이번 미션은 카카오 메시지 API를 사용하여 주문하기 기능을 구현하는 것이었습니다. 

`KakaoController`의 `/oauth/login`을 통해 카카오 로그인에 성공하면 `getAccessToken` 메서드를 거쳐 user의 Email을 추출하고 멤버로 등록하게 하였습니다. 이때 비밀번호는 null을 받을 수 있게 하였습니다. 기존 회원가입을 통해 Member를 등록할 때는 DTO에서 비밀번호를 받을 수 있게끔 되어 있어 괜찮을 것이라 생각했습니다. 

그리고 KakaoToken을 AES 암호화를 거쳐 Repository에 저장하게 하였습니다. 이때 Member와 1대1 연관관계를 갖게 해 member를 통해 토큰을 찾을 수 있게 하였습니다. 그런데 AES 암호화 과정에서 try-cactch할게 너무 많아서 RuntimeException을 상속받는 AesException을 만들어 이를 던지게 해 서비스 계층에서 try-catch를 하지 않아도 되게 해보았습니다. 

이렇게 Member와 토큰이 등록되고 난 후 `OrderController`의  `api/orders`로 Post 요청을 보내면 해당 서비스 계층에서 `createOrder` 메서드가 실행되고 요청 받은 Option을 찾아 quantity를 감소시키고, Wish에 해당 상품이 등록되었다면 삭제하도록 했습니다. Option과 Product가 N:1 연관관계로 등록되어 있어서 Product에서 Option을 찾으면 List 형태로 Product를 반환 받게 하였는데 이게 자연스러운건지 잘 모르겠습니다. 솔직히 아직 연관관계가 잘 이해가 안되는 것 같습니다. 1:N 연관관계라는게 상품 하나당 여러 옵션을 갖을 수 있다. 이렇게 이해하면 되는게 맞을까요? 

`createOrder`의 로직이 전부 완료 되면 마지막에 Order를 레포지토에 저장시키도록 하였습니다. 
`kakaoService`의 `getAccessToken` 메서드가 너무 많은 책임을 가지고 있어서 그런지 테스트코드의 Mock 객체가 많아지는 것 같이 느껴졌습니다. 그런데 테스트코드와 kakaoService를 어떻게 개선시킬 수 있을지 잘 모르겠습니다.  조언해주실 수 있으실까요? 

감사합니다!