### PR TITLE
부산대 BE_오선재 Step2 - 주문하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,73 @@ https://kauth.kakao.com/oauth/authorize
   &response_type=code
   &scope=profile_nickname
 ```
+
+## 📦 Step2 - 주문하기
+
+### 🧩 기능 명세
+
+1. 주문 작성
+
+    - `POST /api/orders`
+    - 요청 Body
+      ```json
+      {
+        "optionId": 17,
+        "quantity": 2,
+        "message": "맛있게 부탁해요!"
+      }
+      ```
+    - 동작
+        1. 옵션 & 재고 검증 → 차감
+        2. 주문 생성
+        3. ( 주문자 ) 위시리스트에서 옵션 제거
+        4. Kakao Message API 로 나에게 보내기 전송
+    - 응답 예시 `201 Created`
+      ```json
+      {
+        "id": 42,
+        "optionId": 17,
+        "quantity": 2,
+        "orderDateTime": "2025‑07‑25T14:00:00",
+        "message": "맛있게 부탁해요!"
+      }
+      ```
+
+2. 주문 상세 조회 `GET /api/orders/{id}`
+3. 주문 내역 페이징 `GET /api/orders?page=&size=`
+4. 기타 보조 API ( Product, Option, Wish ) 는 `/api/**` 네임스페이스 유지
+
+### 🔐 인증·인가 흐름
+
+```Plane Text
+sequenceDiagram
+    actor User
+    participant Front as Front‑end
+    participant Server as Spring Boot
+    participant Kakao as Kakao Server
+
+    User->>Front: Kakao Login 버튼 클릭
+    Front->>Kakao: /oauth/authorize?client_id&redirect_uri
+    Kakao-->>Front: code=abc123 (302)
+    Front->>Server: GET /login/oauth2/code/kakao?code=abc123
+    Server->>Kakao: /oauth/token (code 교환)
+    Kakao-->>Server: access_token
+    Server->>Server: 회원 조회/가입 → JWT 생성
+    Server-->>User: Set‑Cookie: JWT; HttpOnly
+```
+
+### 🗒️ 기능 구현 체크리스트
+
+- [ ] 도메인 모델 설계 ( Order )
+- [ ] **주문 생성 API** `POST /api/orders`
+    - [ ] 옵션 & 재고 검증
+    - [ ] 재고 차감 `option.decreaseStock()`
+    - [ ] 주문 엔티티 저장
+    - [ ] 주문자 위시리스트 항목 삭제
+    - [ ] Kakao *나에게 보내기* 메시지 전송
+- [ ] **주문 상세 조회 API** `GET /api/orders/{id}`
+- [ ] **주문 내역 페이징 API** `GET /api/orders`
+- [ ] 예외 처리 (404 Not Found, 409 Conflict, 502 Bad Gateway 등)
+- [ ] 단위 테스트 (카카오 API Stub)
+
+---

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ kakao.api-url=https://kapi.kakao.com
 #    - 카카오 로그인 후 authorization code 를 받을 콜백 URL
 #    - 반드시 Kakao Developers 콘솔에도 동일하게 등록되어 있어야 함
 kakao.redirect-uri=http://localhost:8080
+
+# 7. 메세지 템플릿 아이디
+kakao.template-id=122845
 ```
 
 Jwt Secret 키는 임의의 Base64 로 인코딩된 문자열을 `JWT_SECRET=` 값에 넣어주면 됩니다.
@@ -195,16 +198,16 @@ sequenceDiagram
 
 ### 🗒️ 기능 구현 체크리스트
 
-- [ ] 도메인 모델 설계 ( Order )
-- [ ] **주문 생성 API** `POST /api/orders`
-    - [ ] 옵션 & 재고 검증
-    - [ ] 재고 차감 `option.decreaseStock()`
-    - [ ] 주문 엔티티 저장
-    - [ ] 주문자 위시리스트 항목 삭제
-    - [ ] Kakao *나에게 보내기* 메시지 전송
-- [ ] **주문 상세 조회 API** `GET /api/orders/{id}`
-- [ ] **주문 내역 페이징 API** `GET /api/orders`
-- [ ] 예외 처리 (404 Not Found, 409 Conflict, 502 Bad Gateway 등)
-- [ ] 단위 테스트 (카카오 API Stub)
+- [x] 도메인 모델 설계 ( Order )
+- [x] **주문 생성 API** `POST /api/orders`
+    - [x] 옵션 & 재고 검증
+    - [x] 재고 차감 `option.decreaseStock()`
+    - [x] 주문 엔티티 저장
+    - [x] 주문자 위시리스트 항목 삭제
+    - [x] Kakao *나에게 보내기* 메시지 전송
+- [x] **주문 상세 조회 API** `GET /api/orders/{id}`
+- [x] **주문 내역 페이징 API** `GET /api/orders`
+- [x] 예외 처리 (404 Not Found, 409 Conflict, 502 Bad Gateway 등)
+- [x] 단위 테스트 (카카오 API Stub)
 
 ---

--- a/src/main/java/gift/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/gift/auth/LoginMemberArgumentResolver.java
@@ -11,6 +11,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.util.WebUtils;
@@ -54,5 +55,18 @@ public class LoginMemberArgumentResolver
 
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+    }
+
+    public Member resolve(HttpServletRequest req) {
+        try {
+            return (Member) resolveArgument(
+                null,
+                null,
+                new ServletWebRequest(req),
+                null
+            );
+        } catch (Exception e) {
+            throw new IllegalStateException("LoginMemberArgumentResolver.resolve 호출 실패", e);
+        }
     }
 }

--- a/src/main/java/gift/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/gift/auth/LoginMemberArgumentResolver.java
@@ -1,6 +1,8 @@
 package gift.auth;
 
 import gift.entity.Member;
+import gift.exception.InvalidAuthorizationHeaderException;
+import gift.exception.MissingAuthorizationHeaderException;
 import gift.repository.MemberRepository;
 import gift.service.TokenService;
 import gift.util.BearerAuthHeaderParser;
@@ -42,31 +44,26 @@ public class LoginMemberArgumentResolver
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter,
+    public Object resolveArgument(
+        MethodParameter parameter,
         ModelAndViewContainer mavContainer,
         NativeWebRequest webRequest,
-        WebDataBinderFactory binderFactory) {
-        HttpServletRequest r = webRequest.getNativeRequest(HttpServletRequest.class);
-
-        String header = tokenExtractor.extractBearerHeader(r);
-        String token = authHeaderParser.extractBearerToken(header);
-        Claims claims = tokenService.parseClaims(token);
-        Long memberId = Long.valueOf(claims.getSubject());
-
-        return memberRepository.findById(memberId)
-            .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+        WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest req = webRequest.getNativeRequest(HttpServletRequest.class);
+        return extractMember(req);
     }
 
     public Member resolve(HttpServletRequest req) {
-        try {
-            return (Member) resolveArgument(
-                null,
-                null,
-                new ServletWebRequest(req),
-                null
-            );
-        } catch (Exception e) {
-            throw new IllegalStateException("LoginMemberArgumentResolver.resolve 호출 실패", e);
-        }
+        return extractMember(req);
+    }
+
+    private Member extractMember(HttpServletRequest req) {
+        String header = tokenExtractor.extractBearerHeader(req);
+        String token  = authHeaderParser .extractBearerToken(header);
+        Claims claims  = tokenService      .parseClaims(token);
+        Long memberId = Long.valueOf(claims.getSubject());
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
     }
 }

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -32,7 +32,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(kakaoTokenInterceptor)
-            .addPathPatterns("/api/**")
+            .addPathPatterns(
+                "/api/orders/**"
+            )
             .order(Ordered.HIGHEST_PRECEDENCE);
     }
 }

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -1,8 +1,11 @@
 package gift.config;
 
+import gift.interceptor.KakaoTokenInterceptor;
 import gift.auth.LoginMemberArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -11,13 +14,25 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+    private final KakaoTokenInterceptor kakaoTokenInterceptor;
 
-    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+    public WebConfig(
+        LoginMemberArgumentResolver loginMemberArgumentResolver,
+        KakaoTokenInterceptor kakaoTokenInterceptor
+    ) {
         this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+        this.kakaoTokenInterceptor = kakaoTokenInterceptor;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
         argumentResolvers.add(loginMemberArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(kakaoTokenInterceptor)
+            .addPathPatterns("/api/**")
+            .order(Ordered.HIGHEST_PRECEDENCE);
     }
 }

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -33,7 +33,9 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(kakaoTokenInterceptor)
             .addPathPatterns(
-                "/api/orders/**"
+                "/api/wishes/**",
+                "/api/orders/**",
+                "/api/products/**"
             )
             .order(Ordered.HIGHEST_PRECEDENCE);
     }

--- a/src/main/java/gift/controller/api/OptionController.java
+++ b/src/main/java/gift/controller/api/OptionController.java
@@ -54,7 +54,7 @@ public class OptionController {
         URI location = URI.create(
             "/api/products/%d/options/%d".formatted(productId, saved.getId()));
         return ResponseEntity.created(location)
-            .body(OptionResponseDto.of(saved));
+            .body(OptionResponseDto.from(saved));
     }
 
     @PutMapping("/{optionId}")
@@ -65,7 +65,7 @@ public class OptionController {
     ) {
         Option updated = optionService.updateOption(productId, optionId, optionRequestDto);
 
-        return ResponseEntity.ok(OptionResponseDto.of(updated));
+        return ResponseEntity.ok(OptionResponseDto.from(updated));
     }
 
     @PatchMapping("/{optionId}/subtract")

--- a/src/main/java/gift/controller/api/OrderController.java
+++ b/src/main/java/gift/controller/api/OrderController.java
@@ -48,7 +48,7 @@ public class OrderController {
         @RequestBody @Valid OrderRequestDto orderRequestDto
     ) {
         Order saved = orderService.addOrderForMember(member, orderRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(OrderResponseDto.of(saved));
+        return ResponseEntity.status(HttpStatus.CREATED).body(OrderResponseDto.from(saved));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/gift/controller/api/OrderController.java
+++ b/src/main/java/gift/controller/api/OrderController.java
@@ -3,14 +3,21 @@ package gift.controller.api;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import gift.auth.LoginMember;
+import gift.dto.api.OrderRequestDto;
+import gift.dto.api.OrderResponseDto;
 import gift.dto.view.OrderViewResponseDto;
 import gift.entity.Member;
+import gift.entity.Order;
 import gift.service.OrderService;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,5 +38,14 @@ public class OrderController {
     ) {
         Page<OrderViewResponseDto> orders = orderService.getOrderListForMember(member, pageable);
         return ResponseEntity.ok(orders);
+    }
+
+    @PostMapping
+    public ResponseEntity<OrderResponseDto> createOrder(
+        @LoginMember Member member,
+        @RequestBody @Valid OrderRequestDto orderRequestDto
+    ) {
+        Order saved = orderService.addOrderForMember(member, orderRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(OrderResponseDto.of(saved));
     }
 }

--- a/src/main/java/gift/controller/api/OrderController.java
+++ b/src/main/java/gift/controller/api/OrderController.java
@@ -15,7 +15,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,5 +49,14 @@ public class OrderController {
     ) {
         Order saved = orderService.addOrderForMember(member, orderRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(OrderResponseDto.of(saved));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteOrder(
+        @LoginMember Member member,
+        @PathVariable Long id
+    ) {
+        orderService.deleteOrderForMember(member, id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/gift/controller/api/OrderController.java
+++ b/src/main/java/gift/controller/api/OrderController.java
@@ -1,0 +1,35 @@
+package gift.controller.api;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import gift.auth.LoginMember;
+import gift.dto.view.OrderViewResponseDto;
+import gift.entity.Member;
+import gift.service.OrderService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<OrderViewResponseDto>> getAllOrders(
+        @LoginMember Member member,
+        @PageableDefault(size = 5, sort = "id", direction = DESC) Pageable pageable
+    ) {
+        Page<OrderViewResponseDto> orders = orderService.getOrderListForMember(member, pageable);
+        return ResponseEntity.ok(orders);
+    }
+}

--- a/src/main/java/gift/controller/view/OrderViewController.java
+++ b/src/main/java/gift/controller/view/OrderViewController.java
@@ -49,7 +49,7 @@ public class OrderViewController {
     ) {
         Product product = productService.getProductById(productId);
         model.addAttribute("product", product);
-        model.addAttribute("orderReq", new OrderRequestDto(null, 1, ""));
+        model.addAttribute("orderReq", new OrderRequestDto());
         return "orders/form";
     }
 

--- a/src/main/java/gift/controller/view/OrderViewController.java
+++ b/src/main/java/gift/controller/view/OrderViewController.java
@@ -45,11 +45,25 @@ public class OrderViewController {
     @GetMapping("/orders/form")
     public String orderForm(
         @RequestParam Long productId,
-        Model model
+        Model model,
+        RedirectAttributes redirectAttributes
     ) {
         Product product = productService.getProductById(productId);
+        if (product.getOptions().isEmpty()) {
+            redirectAttributes.addFlashAttribute(
+                "errorMessage",
+                "상품에 옵션이 없어서 주문을 할 수 없습니다. 옵션이 추가되면 주문해주세요."
+            );
+            return "redirect:/products/" + productId;
+        }
+
+        Long defaultOptionId = product.getOptions().get(0).getId();
+
         model.addAttribute("product", product);
-        model.addAttribute("orderReq", new OrderRequestDto());
+        model.addAttribute(
+            "orderReq",
+            OrderRequestDto.defaultOrderRequestDto(defaultOptionId)
+        );
         return "orders/form";
     }
 

--- a/src/main/java/gift/controller/view/OrderViewController.java
+++ b/src/main/java/gift/controller/view/OrderViewController.java
@@ -1,0 +1,94 @@
+package gift.controller.view;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import gift.auth.LoginMember;
+import gift.dto.api.OrderRequestDto;
+import gift.dto.view.OrderViewResponseDto;
+import gift.entity.Member;
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.repository.OptionRepository;
+import gift.service.OrderService;
+import gift.service.ProductService;
+import jakarta.validation.Valid;
+import java.util.NoSuchElementException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+public class OrderViewController {
+
+    private final OrderService orderService;
+    private final ProductService productService;
+    private final OptionRepository optionRepository;
+
+    public OrderViewController(
+        OrderService orderService,
+        ProductService productService,
+        OptionRepository optionRepository
+    ) {
+        this.orderService = orderService;
+        this.productService = productService;
+        this.optionRepository = optionRepository;
+    }
+
+    @GetMapping("/orders/form")
+    public String orderForm(
+        @RequestParam Long productId,
+        Model model
+    ) {
+        Product product = productService.getProductById(productId);
+        model.addAttribute("product", product);
+        model.addAttribute("orderReq", new OrderRequestDto(null, 1, ""));
+        return "orders/form";
+    }
+
+    @PostMapping("/orders")
+    public String createOrder(
+        @Valid @ModelAttribute("orderReq") OrderRequestDto dto,
+        BindingResult br,
+        @LoginMember Member member,
+        RedirectAttributes rt,
+        Model model
+    ) {
+        if (br.hasErrors()) {
+            Option option = optionRepository.findById(dto.getOptionId())
+                .orElseThrow(() -> new NoSuchElementException("옵션이 존재하지 않습니다."));
+            Product product = productService.getProductById(option.getProduct().getId());
+            model.addAttribute("product", product);
+            return "orders/form";
+        }
+
+        orderService.addOrderForMember(member, dto);
+
+        rt.addFlashAttribute("msg", "주문이 완료되었습니다! 카카오톡을 확인하세요.");
+        return "redirect:/orders/success";
+    }
+
+    @GetMapping("/orders/success")
+    public String orderSuccess() {
+        return "orders/success";
+    }
+
+    @GetMapping("/orders")
+    public String orderList(
+        @LoginMember Member member,
+        @PageableDefault(size = 5, sort = "id", direction = DESC) Pageable pageable,
+        Model model
+    ) {
+        Page<OrderViewResponseDto> orders = orderService.getOrderListForMember(member, pageable);
+
+        model.addAttribute("orders", orders);
+        return "orders/list";
+    }
+}

--- a/src/main/java/gift/dto/api/KakaoTokenResponseDto.java
+++ b/src/main/java/gift/dto/api/KakaoTokenResponseDto.java
@@ -8,5 +8,6 @@ public record KakaoTokenResponseDto(
     String accessToken,
     String refreshToken,
     long expiresIn,
+    long refreshTokenExpiresIn,
     String tokenType
 ) {}

--- a/src/main/java/gift/dto/api/OptionRequestDto.java
+++ b/src/main/java/gift/dto/api/OptionRequestDto.java
@@ -15,12 +15,12 @@ public class OptionRequestDto {
         regexp = "^[a-zA-Z0-9가-힣()\\[\\]+\\-&/_ ]*$",
         message = "유효한 특수문자 ( '( )', '[ ]', '+', '-', '&', '/', '_' ) 가 아닙니다."
     )
-    String name;
+    private String name;
 
     @NotNull(message = "수량은 필수입니다.")
     @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
     @Max(value = 100_000_000, message = "수량은 1억 개 미만이어야 합니다.")
-    Integer quantity;
+    private Integer quantity;
 
     public OptionRequestDto(String name, Integer quantity) {
         this.name = name;

--- a/src/main/java/gift/dto/api/OptionResponseDto.java
+++ b/src/main/java/gift/dto/api/OptionResponseDto.java
@@ -19,7 +19,7 @@ public record OptionResponseDto (
         return quantity;
     }
 
-    public static OptionResponseDto of(Option option) {
+    public static OptionResponseDto from(Option option) {
         return new OptionResponseDto(
             option.getId(),
             option.getName(),

--- a/src/main/java/gift/dto/api/OptionSubtractRequestDto.java
+++ b/src/main/java/gift/dto/api/OptionSubtractRequestDto.java
@@ -9,7 +9,7 @@ public class OptionSubtractRequestDto {
     @NotNull(message = "수량은 필수입니다.")
     @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
     @Max(value = 100_000_000, message = "수량은 1억 개 미만이어야 합니다.")
-    Integer quantity;
+    private Integer quantity;
 
     public OptionSubtractRequestDto(Integer quantity) {
         this.quantity = quantity;

--- a/src/main/java/gift/dto/api/OrderRequestDto.java
+++ b/src/main/java/gift/dto/api/OrderRequestDto.java
@@ -22,6 +22,11 @@ public class OrderRequestDto {
         this.message = message;
     }
 
+    public OrderRequestDto() {
+        this.quantity = 1;
+        this.message = "";
+    }
+
     public Long getOptionId() {
         return optionId;
     }

--- a/src/main/java/gift/dto/api/OrderRequestDto.java
+++ b/src/main/java/gift/dto/api/OrderRequestDto.java
@@ -1,0 +1,36 @@
+package gift.dto.api;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class OrderRequestDto {
+
+    @NotNull(message = "옵션 ID는 필수입니다.")
+    Long optionId;
+
+    @NotNull(message = "옵션 수량은 필수입니다.")
+    @Min(value = 1, message = "한 개 이상 담을 수 있습니다.")
+    Integer quantity;
+
+    @Size(max = 200,message = "요청 메시지는 200자 이하만 가능합니다.")
+    String message;
+
+    public OrderRequestDto(Long optionId, Integer quantity, String message) {
+        this.optionId = optionId;
+        this.quantity = quantity;
+        this.message = message;
+    }
+
+    public Long getOptionId() {
+        return optionId;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/gift/dto/api/OrderRequestDto.java
+++ b/src/main/java/gift/dto/api/OrderRequestDto.java
@@ -22,9 +22,8 @@ public class OrderRequestDto {
         this.message = message;
     }
 
-    public OrderRequestDto() {
-        this.quantity = 1;
-        this.message = "";
+    public static OrderRequestDto defaultOrderRequestDto(Long defaultOptionId) {
+        return new OrderRequestDto(defaultOptionId, 1, "");
     }
 
     public Long getOptionId() {

--- a/src/main/java/gift/dto/api/OrderRequestDto.java
+++ b/src/main/java/gift/dto/api/OrderRequestDto.java
@@ -7,14 +7,14 @@ import jakarta.validation.constraints.Size;
 public class OrderRequestDto {
 
     @NotNull(message = "옵션 ID는 필수입니다.")
-    Long optionId;
+    private Long optionId;
 
     @NotNull(message = "옵션 수량은 필수입니다.")
     @Min(value = 1, message = "한 개 이상 담을 수 있습니다.")
-    Integer quantity;
+    private Integer quantity;
 
     @Size(max = 200,message = "요청 메시지는 200자 이하만 가능합니다.")
-    String message;
+    private String message;
 
     public OrderRequestDto(Long optionId, Integer quantity, String message) {
         this.optionId = optionId;

--- a/src/main/java/gift/dto/api/OrderResponseDto.java
+++ b/src/main/java/gift/dto/api/OrderResponseDto.java
@@ -1,0 +1,43 @@
+package gift.dto.api;
+
+import gift.entity.Order;
+import java.time.LocalDateTime;
+
+public record OrderResponseDto (
+    Long id,
+    Long optionId,
+    int quantity,
+    LocalDateTime orderDateTime,
+    String message
+) {
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getOptionId() {
+        return optionId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public LocalDateTime getOrderDateTime() {
+        return orderDateTime;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public static OrderResponseDto of(Order order) {
+        return new OrderResponseDto(
+            order.getId(),
+            order.getOption().getId(),
+            order.getQuantity(),
+            order.getOrderDateTime(),
+            order.getMessage()
+        );
+    }
+}

--- a/src/main/java/gift/dto/api/OrderResponseDto.java
+++ b/src/main/java/gift/dto/api/OrderResponseDto.java
@@ -31,7 +31,7 @@ public record OrderResponseDto (
         return message;
     }
 
-    public static OrderResponseDto of(Order order) {
+    public static OrderResponseDto from(Order order) {
         return new OrderResponseDto(
             order.getId(),
             order.getOption().getId(),

--- a/src/main/java/gift/dto/api/WishResponseDto.java
+++ b/src/main/java/gift/dto/api/WishResponseDto.java
@@ -1,13 +1,15 @@
 package gift.dto.api;
 
 import gift.entity.WishItem;
+import java.util.List;
 
 public record WishResponseDto(
     Long productId,
     String name,
     int price,
     String imageUrl,
-    int quantity
+    int quantity,
+    List<OptionResponseDto> options
 ) {
 
     public Long getProductId() {
@@ -30,13 +32,20 @@ public record WishResponseDto(
         return quantity;
     }
 
+    public List<OptionResponseDto> getOptions() {
+        return options;
+    }
+
     public static WishResponseDto of(WishItem wi) {
         return new WishResponseDto(
             wi.getProduct().getId(),
             wi.getProduct().getName(),
             wi.getProduct().getPrice(),
             wi.getProduct().getImageUrl(),
-            wi.getQuantity()
+            wi.getQuantity(),
+            wi.getProduct().getOptions().stream().map(
+                option -> new OptionResponseDto(option.getId(), option.getName(),
+                    option.getQuantity())).toList()
         );
     }
 }

--- a/src/main/java/gift/dto/api/WishResponseDto.java
+++ b/src/main/java/gift/dto/api/WishResponseDto.java
@@ -36,7 +36,7 @@ public record WishResponseDto(
         return options;
     }
 
-    public static WishResponseDto of(WishItem wi) {
+    public static WishResponseDto from(WishItem wi) {
         return new WishResponseDto(
             wi.getProduct().getId(),
             wi.getProduct().getName(),

--- a/src/main/java/gift/dto/view/OrderViewResponseDto.java
+++ b/src/main/java/gift/dto/view/OrderViewResponseDto.java
@@ -36,7 +36,7 @@ public record OrderViewResponseDto (
         return message;
     }
 
-    public static OrderViewResponseDto of(Order order) {
+    public static OrderViewResponseDto from(Order order) {
         return new OrderViewResponseDto(
             order.getId(),
             order.getOption().getName(),

--- a/src/main/java/gift/dto/view/OrderViewResponseDto.java
+++ b/src/main/java/gift/dto/view/OrderViewResponseDto.java
@@ -1,0 +1,49 @@
+package gift.dto.view;
+
+import gift.entity.Order;
+import java.time.LocalDateTime;
+
+public record OrderViewResponseDto (
+    Long id,
+    String productName,
+    String optionName,
+    int quantity,
+    String message,
+    LocalDateTime orderDateTime
+) {
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public String getOptionName() {
+        return optionName;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public LocalDateTime getOrderDateTime() {
+        return orderDateTime;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public static OrderViewResponseDto of(Order order) {
+        return new OrderViewResponseDto(
+            order.getId(),
+            order.getOption().getName(),
+            order.getOption().getProduct().getName(),
+            order.getQuantity(),
+            order.getMessage(),
+            order.getOrderDateTime()
+        );
+    }
+}

--- a/src/main/java/gift/entity/KakaoTokens.java
+++ b/src/main/java/gift/entity/KakaoTokens.java
@@ -1,0 +1,70 @@
+package gift.entity;
+
+import gift.dto.api.KakaoTokenResponseDto;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+
+@Embeddable
+public class KakaoTokens {
+
+    private final String accessToken;
+    private final String refreshToken;
+    private final LocalDateTime accessExpiresAt;
+    private final LocalDateTime refreshExpiresAt;
+
+    protected KakaoTokens() {
+        this.accessToken = null;
+        this.refreshToken = null;
+        this.accessExpiresAt = null;
+        this.refreshExpiresAt = null;
+    }
+
+    private KakaoTokens(String accessToken, String refreshToken, LocalDateTime accessExpiresAt, LocalDateTime refreshExpiresAt) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.accessExpiresAt = accessExpiresAt;
+        this.refreshExpiresAt = refreshExpiresAt;
+    }
+
+    public static KakaoTokens of(KakaoTokenResponseDto kakaoTokenResponseDto) {
+        return new KakaoTokens(
+            kakaoTokenResponseDto.accessToken(),
+            kakaoTokenResponseDto.refreshToken(),
+            LocalDateTime.now().plusSeconds(kakaoTokenResponseDto.expiresIn()),
+            LocalDateTime.now().plusDays(30)
+        );
+    }
+
+    public KakaoTokens withNewAccessToken(String accessToken, long expiresIn) {
+        return new KakaoTokens(
+            accessToken,
+            this.refreshToken,
+            LocalDateTime.now().plusSeconds(expiresIn),
+            this.refreshExpiresAt
+        );
+    }
+
+    public boolean isAceessExpired() {
+        return accessExpiresAt.isBefore(LocalDateTime.now().plusSeconds(60));
+    }
+
+    public boolean isRefreshExpired() {
+        return refreshExpiresAt.isBefore(LocalDateTime.now());
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public LocalDateTime getAccessExpiresAt() {
+        return accessExpiresAt;
+    }
+
+    public LocalDateTime getRefreshExpiresAt() {
+        return refreshExpiresAt;
+    }
+}

--- a/src/main/java/gift/entity/KakaoTokens.java
+++ b/src/main/java/gift/entity/KakaoTokens.java
@@ -26,12 +26,12 @@ public class KakaoTokens {
         this.refreshExpiresAt = refreshExpiresAt;
     }
 
-    public static KakaoTokens of(KakaoTokenResponseDto kakaoTokenResponseDto) {
+    public static KakaoTokens from(KakaoTokenResponseDto kakaoTokenResponseDto) {
         return new KakaoTokens(
             kakaoTokenResponseDto.accessToken(),
             kakaoTokenResponseDto.refreshToken(),
             LocalDateTime.now().plusSeconds(kakaoTokenResponseDto.expiresIn()),
-            LocalDateTime.now().plusDays(30)
+            LocalDateTime.now().plusDays(kakaoTokenResponseDto.refreshTokenExpiresIn())
         );
     }
 

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -143,7 +143,7 @@ public class Member {
     }
 
     public void refreshTokens(KakaoTokenResponseDto dto) {
-        this.kakaoTokens = KakaoTokens.of(dto);
+        this.kakaoTokens = KakaoTokens.from(dto);
     }
 
     public void updateAccessToken(String newAccessToken, long expiresIn) {

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -1,7 +1,11 @@
 package gift.entity;
 
+import gift.dto.api.KakaoTokenResponseDto;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -32,6 +36,13 @@ public class Member {
 
     private String nickname;
 
+    @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name = "accessToken", column = @Column(length = 2048)),
+        @AttributeOverride(name = "refreshToken", column = @Column(length = 2048))
+    })
+    private KakaoTokens kakaoTokens;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WishItem> wishItems = new ArrayList<>();
 
@@ -58,6 +69,15 @@ public class Member {
         }
         this.kakaoId  = kakaoId;
         this.nickname = nickname;
+    }
+
+    public Member(Long kakaoId, String nickname, KakaoTokens kakaoTokens) {
+        if (kakaoId == null) {
+            throw new IllegalArgumentException("카카오 ID는 필수입니다.");
+        }
+        this.kakaoId  = kakaoId;
+        this.nickname = nickname;
+        this.kakaoTokens = kakaoTokens;
     }
 
     private void validate(String email, String password) {
@@ -100,5 +120,33 @@ public class Member {
 
     public String getNickname() {
         return nickname;
+    }
+
+    public boolean isKakaoUser() {
+        return kakaoTokens != null;
+    }
+
+    public String getAccessToken() {
+        return kakaoTokens.getAccessToken();
+    }
+
+    public String getRefreshToken() {
+        return kakaoTokens.getRefreshToken();
+    }
+
+    public boolean accessTokenExpired() {
+        return kakaoTokens.isAceessExpired();
+    }
+
+    public boolean refreshTokenExpired() {
+        return kakaoTokens.isRefreshExpired();
+    }
+
+    public void refreshTokens(KakaoTokenResponseDto dto) {
+        this.kakaoTokens = KakaoTokens.of(dto);
+    }
+
+    public void updateAccessToken(String newAccessToken, long expiresIn) {
+        this.kakaoTokens = kakaoTokens.withNewAccessToken(newAccessToken, expiresIn);
     }
 }

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -35,6 +35,9 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WishItem> wishItems = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Order> orders = new ArrayList<>();
+
     public Member(Long id, String email, String password) {
         validate(email, password);
 

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -1,6 +1,7 @@
 package gift.entity;
 
 import gift.exception.InsufficientStockException;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -16,6 +18,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -43,6 +47,9 @@ public class Option {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "product_id")
     private Product product;
+
+    @OneToMany(mappedBy = "option", cascade = CascadeType.ALL)
+    private List<Order> orders = new ArrayList<>();
 
     protected Option() {}
 

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -40,7 +40,7 @@ public class Option {
     private String name;
 
     @Column(nullable = false)
-    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    @Min(value = 0, message = "수량은 0개 이상이어야 합니다.")
     @Max(value = 100_000_000, message = "수량은 1억 개 미만이어야 합니다.")
     private int quantity;
 

--- a/src/main/java/gift/entity/Order.java
+++ b/src/main/java/gift/entity/Order.java
@@ -1,0 +1,94 @@
+package gift.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    @Max(value = 100_000_000, message = "수량은 1억 개 미만이어야 합니다.")
+    private int quantity;
+
+    @Column(nullable = false)
+    @Size(max = 200, message = "요청 메시지는 200자 이하만 가능합니다.")
+    private String message;
+
+    @Column(nullable = false, updatable = false)
+    @CreationTimestamp
+    private LocalDateTime orderDateTime;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "option_id")
+    private Option option;
+
+    protected Order() {}
+
+    public Order(
+        int quantity,
+        String message,
+        LocalDateTime orderDateTime,
+        Member member,
+        Option option
+    ) {
+        this.quantity = quantity;
+        this.message = message;
+        this.orderDateTime = orderDateTime;
+        this.member = member;
+        this.option = option;
+    }
+
+    public Order(int quantity, String message, Member member, Option option) {
+        this.quantity = quantity;
+        this.message = message;
+        this.member = member;
+        this.option = option;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Option getOption() {
+        return option;
+    }
+
+    public LocalDateTime getOrderDateTime() {
+        return orderDateTime;
+    }
+}

--- a/src/main/java/gift/entity/Order.java
+++ b/src/main/java/gift/entity/Order.java
@@ -62,10 +62,7 @@ public class Order {
     }
 
     public Order(int quantity, String message, Member member, Option option) {
-        this.quantity = quantity;
-        this.message = message;
-        this.member = member;
-        this.option = option;
+        this(quantity, message, LocalDateTime.now(), member, option);
     }
 
     public Long getId() {

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -81,6 +81,6 @@ public class Product {
     }
 
     public List<Option> getOptions() {
-        return options;
+        return new ArrayList<>(options);
     }
 }

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -79,4 +79,8 @@ public class Product {
     public String getImageUrl() {
         return imageUrl;
     }
+
+    public List<Option> getOptions() {
+        return options;
+    }
 }

--- a/src/main/java/gift/exception/ExternalServiceException.java
+++ b/src/main/java/gift/exception/ExternalServiceException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class ExternalServiceException extends RuntimeException {
+
+    public ExternalServiceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -184,4 +184,11 @@ public class GlobalExceptionHandler {
         error.put("error", e.getMessage());
         return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
     }
+
+    @ExceptionHandler(ExternalServiceException.class)
+    public ResponseEntity<Map<String, String>> handleExternalService(ExternalServiceException e) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", e.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.BAD_GATEWAY);
+    }
 }

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -177,4 +177,11 @@ public class GlobalExceptionHandler {
         }
         return HttpStatus.INTERNAL_SERVER_ERROR;
     }
+
+    @ExceptionHandler(ReauthorizeRequiredException.class)
+    public ResponseEntity<Map<String, String>> handleReauthorizeRequired(ReauthorizeRequiredException e) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", e.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
 }

--- a/src/main/java/gift/exception/ReauthorizeRequiredException.java
+++ b/src/main/java/gift/exception/ReauthorizeRequiredException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class ReauthorizeRequiredException extends RuntimeException {
+
+    public ReauthorizeRequiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/interceptor/KakaoTokenInterceptor.java
+++ b/src/main/java/gift/interceptor/KakaoTokenInterceptor.java
@@ -5,7 +5,9 @@ import gift.entity.Member;
 import gift.service.KakaoTokenManager;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
@@ -28,8 +30,17 @@ public class KakaoTokenInterceptor implements HandlerInterceptor {
         HttpServletResponse res,
         Object handler
     ) {
-        Member member = resolver.resolve(req);
+        if (!(handler instanceof HandlerMethod hm)) {
+            return true;
+        }
 
+        boolean requiresAuth = Arrays.stream(hm.getMethodParameters())
+            .anyMatch(resolver::supportsParameter);
+        if (!requiresAuth) {
+            return true;
+        }
+
+        Member member = resolver.resolve(req);
         if (member.isKakaoUser()) {
             tokenManager.ensureAccessToken(member.getId());
         }

--- a/src/main/java/gift/interceptor/KakaoTokenInterceptor.java
+++ b/src/main/java/gift/interceptor/KakaoTokenInterceptor.java
@@ -1,0 +1,38 @@
+package gift.interceptor;
+
+import gift.auth.LoginMemberArgumentResolver;
+import gift.entity.Member;
+import gift.service.KakaoTokenManager;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class KakaoTokenInterceptor implements HandlerInterceptor {
+
+    private final KakaoTokenManager tokenManager;
+    private final LoginMemberArgumentResolver resolver;
+
+    public KakaoTokenInterceptor(
+        KakaoTokenManager tokenManager,
+        LoginMemberArgumentResolver resolver
+    ) {
+        this.tokenManager = tokenManager;
+        this.resolver = resolver;
+    }
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest req,
+        HttpServletResponse res,
+        Object handler
+    ) {
+        Member member = resolver.resolve(req);
+
+        if (member.isKakaoUser()) {
+            tokenManager.ensureAccessToken(member.getId());
+        }
+        return true;
+    }
+}

--- a/src/main/java/gift/repository/OrderRepository.java
+++ b/src/main/java/gift/repository/OrderRepository.java
@@ -1,0 +1,13 @@
+package gift.repository;
+
+import gift.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @EntityGraph(attributePaths = {"option", "member"})
+    Page<Order> findByMemberId(Long memberId, Pageable pageable);
+}

--- a/src/main/java/gift/service/KakaoMessageService.java
+++ b/src/main/java/gift/service/KakaoMessageService.java
@@ -1,0 +1,85 @@
+package gift.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.entity.Option;
+import gift.entity.Order;
+import gift.entity.Product;
+import gift.exception.ExternalServiceException;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class KakaoMessageService {
+
+    @Value("${kakao.api-url}")
+    private final String apiUrl;
+
+    private final WebClient kakaoClient;
+    private final ObjectMapper objectMapper;
+
+    public KakaoMessageService(
+        @Value("${kakao.api-url}") String apiUrl,
+        WebClient.Builder builder,
+        ObjectMapper objectMapper
+    ) {
+        this.apiUrl = apiUrl;
+        this.kakaoClient = builder.baseUrl(apiUrl).build();
+        this.objectMapper = objectMapper;
+    }
+
+    @Value("${kakao.template-id}")
+    private Long templateId;
+
+    public void sendOrderMemo(Order order, String accessToken) {
+        try {
+            MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+            form.add("template_id", String.valueOf(templateId));
+            form.add("template_args", buildTemplateArgs(order));
+
+            Map<?, ?> resp = kakaoClient.post()
+                .uri("/v2/api/talk/memo/send")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(form))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+
+            if (!Objects.equals(resp.get("result_code"), 0)) {
+                throw new ExternalServiceException("카카오톡 전송 실패: " + resp);
+            }
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("template_args 직렬화 실패");
+        }
+    }
+
+    private String buildTemplateArgs(Order order) throws JsonProcessingException {
+        Option option   = order.getOption();
+        Product product = option.getProduct();
+
+        Map<String, Object> args = Map.of(
+            "PRODUCT_TOTAL_PRICE", product.getPrice() * order.getQuantity(),
+            "PRODUCT_PRICE", product.getPrice(),
+            "ORDER_TIME", order.getOrderDateTime()
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
+            "PRODUCT_IMAGE_URL", product.getImageUrl(),
+            "PRODUCT_NAME", product.getName(),
+            "OPTION_NAME", option.getName(),
+            "ORDER_QUANTITY", order.getQuantity(),
+            "ORDER_MESSAGE", order.getMessage()
+        );
+
+        return objectMapper.writeValueAsString(args);
+    }
+}

--- a/src/main/java/gift/service/KakaoMessageService.java
+++ b/src/main/java/gift/service/KakaoMessageService.java
@@ -47,7 +47,7 @@ public class KakaoMessageService {
             form.add("template_id", String.valueOf(templateId));
             form.add("template_args", buildTemplateArgs(order));
 
-            Map<?, ?> resp = kakaoClient.post()
+            Map<String, Object> resp = kakaoClient.post()
                 .uri("/v2/api/talk/memo/send")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)

--- a/src/main/java/gift/service/KakaoOAuthService.java
+++ b/src/main/java/gift/service/KakaoOAuthService.java
@@ -90,4 +90,17 @@ public class KakaoOAuthService {
             .timeout(Duration.ofSeconds(3))
             .block();
     }
+
+    public KakaoTokenResponseDto refreshTokenGrant(String refreshToken) {
+        return webClient.post()
+            .uri("/oauth/token")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(BodyInserters.fromFormData("grant_type", "refresh_token")
+                .with("client_id", clientId)
+                .with("refresh_token", refreshToken)
+            )
+            .retrieve()
+            .bodyToMono(KakaoTokenResponseDto.class)
+            .block();
+    }
 }

--- a/src/main/java/gift/service/KakaoOAuthService.java
+++ b/src/main/java/gift/service/KakaoOAuthService.java
@@ -18,7 +18,7 @@ import reactor.netty.http.client.HttpClient;
 @Service
 public class KakaoOAuthService {
 
-    @Value("${kakao.clientId}")
+    @Value("${kakao.client-id}")
     private final String clientId;
 
     @Value("${kakao.auth-url}")
@@ -27,16 +27,16 @@ public class KakaoOAuthService {
     @Value("${kakao.api-url}")
     private final String apiUrl;
 
-    @Value("${kakao.redirect-uri:}")
+    @Value("${kakao.redirect-uri}")
     private final String redirectUri;
 
     private final WebClient webClient;
 
     public KakaoOAuthService(
-        @Value("${kakao.clientId}") String clientId,
+        @Value("${kakao.client-id}") String clientId,
         @Value("${kakao.auth-url}") String authUrl,
         @Value("${kakao.api-url}") String apiUrl,
-        @Value("${kakao.redirect-uri:}") String redirectUri,
+        @Value("${kakao.redirect-uri}") String redirectUri,
         WebClient.Builder builder
     ) {
         this.clientId   = clientId;

--- a/src/main/java/gift/service/KakaoTokenManager.java
+++ b/src/main/java/gift/service/KakaoTokenManager.java
@@ -1,0 +1,41 @@
+package gift.service;
+
+import gift.dto.api.KakaoTokenResponseDto;
+import gift.entity.Member;
+import gift.exception.ReauthorizeRequiredException;
+import gift.repository.MemberRepository;
+import java.util.NoSuchElementException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class KakaoTokenManager {
+
+    private final KakaoOAuthService kakaoOAuthService;
+    private final MemberRepository memberRepository;
+
+    public KakaoTokenManager(
+        KakaoOAuthService kakaoOAuthService,
+        MemberRepository memberRepository
+    ) {
+        this.kakaoOAuthService = kakaoOAuthService;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public String ensureAccessToken(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new NoSuchElementException("회원이 없습니다."));
+
+        if (member.accessTokenExpired()) {
+            if (member.refreshTokenExpired()) {
+                throw new ReauthorizeRequiredException("Refresh token이 만료되어, 사용자의 재승인이 필요합니다.");
+            }
+            KakaoTokenResponseDto dto = kakaoOAuthService.refreshTokenGrant(
+                member.getRefreshToken()
+            );
+            member.updateAccessToken(dto.accessToken(), dto.expiresIn());
+        }
+        return member.getAccessToken();
+    }
+}

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -3,6 +3,7 @@ package gift.service;
 import gift.dto.api.KakaoTokenResponseDto;
 import gift.dto.api.KakaoUserResponseDto;
 import gift.dto.api.MemberRegisterRequestDto;
+import gift.entity.KakaoTokens;
 import gift.entity.Member;
 import gift.exception.InvalidCredentialsException;
 import gift.repository.MemberRepository;
@@ -70,8 +71,10 @@ public class MemberService {
 
         Member member = memberRepository.findByKakaoId(kakaoId)
             .orElseGet(() ->
-                memberRepository.save(new Member(kakaoId, nickname))
+                memberRepository.save(new Member(kakaoId, nickname, KakaoTokens.of(tokenDto)))
             );
+
+        member.refreshTokens(tokenDto);
 
         return tokenService.generateToken(member.getId(), nickname);
     }

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -71,7 +71,7 @@ public class MemberService {
 
         Member member = memberRepository.findByKakaoId(kakaoId)
             .orElseGet(() ->
-                memberRepository.save(new Member(kakaoId, nickname, KakaoTokens.of(tokenDto)))
+                memberRepository.save(new Member(kakaoId, nickname, KakaoTokens.from(tokenDto)))
             );
 
         member.refreshTokens(tokenDto);

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -30,7 +30,7 @@ public class OptionService {
     public Page<OptionResponseDto> getOptionList(Long productId, Pageable pageable) {
         return optionRepository
             .findAllByProductId(productId, pageable)
-            .map(OptionResponseDto::of);
+            .map(OptionResponseDto::from);
     }
 
     public Option addOption(Long productId, OptionRequestDto optionRequestDto) {

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -22,17 +22,20 @@ public class OrderService {
     private final OptionRepository optionRepository;
     private final WishRepository wishRepository;
     private final OptionService optionService;
+    private final KakaoMessageService kakaoMessageService;
 
     public OrderService(
         OrderRepository orderRepository,
         OptionRepository optionRepository,
         WishRepository wishRepository,
-        OptionService optionService
+        OptionService optionService,
+        KakaoMessageService kakaoMessageService
     ) {
         this.orderRepository = orderRepository;
         this.optionRepository = optionRepository;
         this.wishRepository = wishRepository;
         this.optionService = optionService;
+        this.kakaoMessageService = kakaoMessageService;
     }
 
     @Transactional(readOnly = true)
@@ -58,6 +61,7 @@ public class OrderService {
             )
         );
         wishRepository.deleteByMemberIdAndProductId(member.getId(), option.getProduct().getId());
+        kakaoMessageService.sendOrderMemo(saved, member.getAccessToken());
         return saved;
     }
 

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -61,6 +61,13 @@ public class OrderService {
         return saved;
     }
 
+    public void deleteOrderForMember(Member member, Long id) {
+        validateMember(member);
+        orderRepository.findById(id)
+            .orElseThrow(() -> new NoSuchElementException("주문을 찾을 수 없습니다."));
+        orderRepository.deleteById(id);
+    }
+
     private void validateMember(Member member) {
         if (member == null)
             throw new InvalidMemberException("유효하지 않은 회원입니다.");

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -1,0 +1,33 @@
+package gift.service;
+
+import gift.dto.view.OrderViewResponseDto;
+import gift.entity.Member;
+import gift.exception.InvalidMemberException;
+import gift.repository.OrderRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    public OrderService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<OrderViewResponseDto> getOrderListForMember(Member member, Pageable pageable) {
+        validateMember(member);
+        return orderRepository
+            .findByMemberId(member.getId(), pageable)
+            .map(OrderViewResponseDto::of);
+    }
+
+    private void validateMember(Member member) {
+        if (member == null)
+            throw new InvalidMemberException("유효하지 않은 회원입니다.");
+    }
+}

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -43,7 +43,7 @@ public class OrderService {
         validateMember(member);
         return orderRepository
             .findByMemberId(member.getId(), pageable)
-            .map(OrderViewResponseDto::of);
+            .map(OrderViewResponseDto::from);
     }
 
     @Transactional

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -1,9 +1,15 @@
 package gift.service;
 
+import gift.dto.api.OrderRequestDto;
 import gift.dto.view.OrderViewResponseDto;
 import gift.entity.Member;
+import gift.entity.Option;
+import gift.entity.Order;
 import gift.exception.InvalidMemberException;
+import gift.repository.OptionRepository;
 import gift.repository.OrderRepository;
+import gift.repository.WishRepository;
+import java.util.NoSuchElementException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -13,9 +19,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final OptionRepository optionRepository;
+    private final WishRepository wishRepository;
+    private final OptionService optionService;
 
-    public OrderService(OrderRepository orderRepository) {
+    public OrderService(
+        OrderRepository orderRepository,
+        OptionRepository optionRepository,
+        WishRepository wishRepository,
+        OptionService optionService
+    ) {
         this.orderRepository = orderRepository;
+        this.optionRepository = optionRepository;
+        this.wishRepository = wishRepository;
+        this.optionService = optionService;
     }
 
     @Transactional(readOnly = true)
@@ -24,6 +41,24 @@ public class OrderService {
         return orderRepository
             .findByMemberId(member.getId(), pageable)
             .map(OrderViewResponseDto::of);
+    }
+
+    @Transactional
+    public Order addOrderForMember(Member member, OrderRequestDto orderRequestDto) {
+        validateMember(member);
+        Option option = optionRepository.findById(orderRequestDto.getOptionId())
+            .orElseThrow(() -> new NoSuchElementException("옵션을 찾을 수 없습니다."));
+        optionService.subtractQuantity(option.getId(), orderRequestDto.getQuantity());
+        Order saved = orderRepository.save(
+            new Order(
+                orderRequestDto.getQuantity(),
+                orderRequestDto.getMessage(),
+                member,
+                option
+            )
+        );
+        wishRepository.deleteByMemberIdAndProductId(member.getId(), option.getProduct().getId());
+        return saved;
     }
 
     private void validateMember(Member member) {

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -34,7 +34,7 @@ public class WishService {
         validateMember(member);
         return wishRepository
             .findAllByMemberId(member.getId(), pageable)
-            .map(WishResponseDto::of);
+            .map(WishResponseDto::from);
     }
 
     public void addWishItemForMember(Member member, WishRequestDto wishRequestDto) {

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,9 +1,9 @@
-INSERT INTO products (name, price, image_url) VALUES ('초콜릿', 1000, 'http://localhost:8080/image/chocolate.webp');
-INSERT INTO products (name, price, image_url) VALUES ('새우깡', 1500, 'http://localhost:8080/image/shrimpCrackers.webp');
-INSERT INTO products (name, price, image_url) VALUES ('커피', 1500, 'http://localhost:8080/image/coffee.png');
-INSERT INTO products (name, price, image_url) VALUES ('김밥', 2000, 'http://localhost:8080/image/kimbap.png');
-INSERT INTO products (name, price, image_url) VALUES ('라면', 1000, 'http://localhost:8080/image/ramen.png');
-INSERT INTO products (name, price, image_url) VALUES ('젤리', 1000, 'http://localhost:8080/image/jelly.png');
+INSERT INTO products (name, price, image_url) VALUES ('초콜릿', 1000, 'https://i.imgur.com/ZU9CL58.png');
+INSERT INTO products (name, price, image_url) VALUES ('새우깡', 1500, 'https://i.imgur.com/YxTseJH.png');
+INSERT INTO products (name, price, image_url) VALUES ('커피', 1500, 'https://i.imgur.com/J55LFRc.png');
+INSERT INTO products (name, price, image_url) VALUES ('김밥', 2000, 'https://i.imgur.com/EA8US8c.png');
+INSERT INTO products (name, price, image_url) VALUES ('라면', 1000, 'https://i.imgur.com/NMp72cw.png');
+INSERT INTO products (name, price, image_url) VALUES ('젤리', 1000, 'https://i.imgur.com/sFFjwua.png');
 
 INSERT INTO approved_products (name) VALUES ('카카오 프렌즈 필통');
 INSERT INTO approved_products (name) VALUES ('카카오 프렌즈 인형');

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -14,8 +14,8 @@
 
 <a th:href="@{
   https://kauth.kakao.com/oauth/authorize(
-    client_id=${@environment.getProperty('kakao.clientId')},
-    redirect_uri='http://localhost:8080',
+    client_id=${@environment.getProperty('kakao.client-id')},
+    redirect_uri=${@environment.getProperty('kakao.redirect-uri')},
     response_type='code',
     scope='profile_nickname')}">
   <img src="/img/kakao_login.png" alt="카카오 로그인">

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -17,7 +17,7 @@
     client_id=${@environment.getProperty('kakao.client-id')},
     redirect_uri=${@environment.getProperty('kakao.redirect-uri')},
     response_type='code',
-    scope='profile_nickname')}">
+    scope='profile_nickname,talk_message')}">
   <img src="/img/kakao_login.png" alt="카카오 로그인">
 </a>
 

--- a/src/main/resources/templates/orders/form.html
+++ b/src/main/resources/templates/orders/form.html
@@ -16,11 +16,13 @@
       method="post">
 
   <label>옵션 선택</label>
-  <select th:field="*{optionId}" required>
+  <select th:field="*{optionId}"
+          th:data-product-price="${product.price}"
+          required>
     <option
         th:each="opt : ${product.options}"
         th:value="${opt.id}"
-        th:text="${opt.name + ' (' + opt.quantity + '개 재고 · ' + #numbers.formatInteger(product.price,0) + '원)'}"
+        th:text="${opt.name + ' (' + opt.quantity + '개 재고)'}"
         th:data-stock="${opt.quantity}">
     </option>
   </select>
@@ -31,7 +33,7 @@
          min="1"
          value="1" required/>
 
-  <p>총액: <span id="total" th:text="${#numbers.formatInteger(product.price,0)}">0</span>원</p>
+  <p>총합: <span id="total">0</span>원</p>
 
   <label>요청사항(선택)</label>
   <textarea th:field="*{message}"
@@ -45,17 +47,18 @@
 </form>
 
 <script>
-  const select = document.querySelector('select[name="optionId"]');
-  const qty    = document.querySelector('input[name="quantity"]');
-  const total  = document.getElementById('total');
+  const select       = document.querySelector('select[name="optionId"]');
+  const qty          = document.querySelector('input[name="quantity"]');
+  const total        = document.getElementById('total');
+  const productPrice = Number(select.dataset.productPrice);
 
   function recalc() {
-    const price = +select.selectedOptions[0].dataset.price;
-    const count = +qty.value;
-    total.textContent = (price * count).toLocaleString();
+    const count = Number(qty.value || 0);
+    total.textContent = (productPrice * count).toLocaleString();
   }
+
   select.addEventListener('change', recalc);
-  qty.addEventListener('input', recalc);
+  qty   .addEventListener('input' , recalc);
   recalc();
 </script>
 </body>

--- a/src/main/resources/templates/orders/form.html
+++ b/src/main/resources/templates/orders/form.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>주문하기</title>
+  <style>
+  </style>
+</head>
+<body>
+<h1>상품명: <span th:text="${product.name}"></span></h1>
+<img th:src="${product.imageUrl}" alt="상품 이미지" width="250">
+<p>단가: <strong th:text="${#numbers.formatInteger(product.price,0)}"></strong>원</p>
+
+<form th:action="@{/orders}"
+      th:object="${orderReq}"
+      method="post">
+
+  <label>옵션 선택</label>
+  <select th:field="*{optionId}" required>
+    <option
+        th:each="opt : ${product.options}"
+        th:value="${opt.id}"
+        th:text="${opt.name + ' (' + opt.quantity + '개 재고 · ' + #numbers.formatInteger(product.price,0) + '원)'}"
+        th:data-stock="${opt.quantity}">
+    </option>
+  </select>
+
+  <label>수량</label>
+  <input type="number"
+         th:field="*{quantity}"
+         min="1"
+         value="1" required/>
+
+  <p>총액: <span id="total" th:text="${#numbers.formatInteger(product.price,0)}">0</span>원</p>
+
+  <label>요청사항(선택)</label>
+  <textarea th:field="*{message}"
+            rows="3"
+            placeholder="요청사항을 입력하세요"></textarea>
+
+  <div>
+    <button type="submit">주문하기</button>
+    <a th:href="@{/products/{id}(id=${product.id})}">취소</a>
+  </div>
+</form>
+
+<script>
+  const select = document.querySelector('select[name="optionId"]');
+  const qty    = document.querySelector('input[name="quantity"]');
+  const total  = document.getElementById('total');
+
+  function recalc() {
+    const price = +select.selectedOptions[0].dataset.price;
+    const count = +qty.value;
+    total.textContent = (price * count).toLocaleString();
+  }
+  select.addEventListener('change', recalc);
+  qty.addEventListener('input', recalc);
+  recalc();
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/orders/list.html
+++ b/src/main/resources/templates/orders/list.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>내 주문 내역</title>
+  <style>
+    table { width:100%; border-collapse: collapse; }
+    th, td { padding:.5rem; border:1px solid #ddd; }
+    th { background:#f5f5f5; }
+    .pagination { list-style:none; display:flex; gap:.5rem; padding:0; }
+    .pagination li { }
+    .pagination li.active a { font-weight:bold; }
+    .pagination a { text-decoration:none; padding:.2rem .5rem; border:1px solid #ccc; }
+  </style>
+</head>
+<body>
+<h1>📦 내 주문 내역</h1>
+<p><a th:href="@{/products}">&larr; 메인으로</a></p>
+
+<table>
+  <thead>
+  <tr>
+    <th>주문번호</th><th>상품명</th><th>옵션명</th>
+    <th>수량</th><th>요청사항</th><th>주문일시</th><th>상세</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="o : ${orders.content}">
+    <td th:text="${o.id}">1</td>
+    <td th:text="${o.productName}">상품명</td>
+    <td th:text="${o.optionName}">옵션명</td>
+    <td th:text="${o.quantity}">수량</td>
+    <td th:text="${o.message}">요청사항</td>
+    <td th:text="${#temporals.format(o.orderDateTime, 'yyyy-MM-dd HH:mm')}">2025-07-28 14:35</td>
+  </tr>
+  <tr th:if="${#lists.isEmpty(orders.content)}">
+    <td colspan="7" style="text-align:center; padding:2rem;">
+      아직 주문 내역이 없습니다.
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+<nav th:if="${orders.totalPages > 1}">
+  <ul class="pagination">
+    <li th:classappend="${orders.first} ? 'disabled'">
+      <a th:href="@{/orders(page=${orders.number-1}, size=${orders.size})}"
+         th:if="${!orders.first}">Prev</a>
+      <span th:if="${orders.first}">Prev</span>
+    </li>
+
+    <li th:each="i : ${#numbers.sequence(0, orders.totalPages - 1)}"
+        th:classappend="${i == orders.number} ? 'active'">
+      <a th:href="@{/orders(page=${i}, size=${orders.size})}"
+         th:text="${i + 1}">1</a>
+    </li>
+
+    <li th:classappend="${orders.last} ? 'disabled'">
+      <a th:href="@{/orders(page=${orders.number+1}, size=${orders.size})}"
+         th:if="${!orders.last}">Next</a>
+      <span th:if="${orders.last}">Next</span>
+    </li>
+  </ul>
+</nav>
+</body>
+</html>

--- a/src/main/resources/templates/orders/success.html
+++ b/src/main/resources/templates/orders/success.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>주문 완료</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 600px;
+      margin: 4rem auto;
+      text-align: center;
+    }
+    .message {
+      font-size: 1.2rem;
+      margin-bottom: 2rem;
+      color: #4a90e2;
+    }
+    .actions a {
+      display: inline-block;
+      margin: 0 .5rem;
+      padding: .5rem 1rem;
+      background: #4a90e2;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 4px;
+    }
+    .actions a.cancel {
+      background: #aaa;
+    }
+  </style>
+</head>
+<body>
+
+<h1>🎉 주문이 완료되었습니다! 🎉</h1>
+
+<p class="message" th:text="${msg}">주문이 성공적으로 접수되었습니다.</p>
+
+<div class="actions">
+  <a th:href="@{/orders}" >주문 내역 보기</a>
+  <a th:href="@{/}" class="cancel">메인으로</a>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/products/user/detail.html
+++ b/src/main/resources/templates/products/user/detail.html
@@ -19,6 +19,11 @@
     </p>
   </div>
 
+  <a th:href="@{/orders/form(productId=${product.id})}"
+     class="btn">
+    주문하기
+  </a>
+
   <h3>옵션 선택</h3>
   <ul>
     <li th:each="opt : ${options}">

--- a/src/main/resources/templates/products/user/detail.html
+++ b/src/main/resources/templates/products/user/detail.html
@@ -19,6 +19,8 @@
     </p>
   </div>
 
+  <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+
   <a th:href="@{/orders/form(productId=${product.id})}"
      class="btn">
     주문하기

--- a/src/test/java/gift/MemberServiceTest.java
+++ b/src/test/java/gift/MemberServiceTest.java
@@ -48,6 +48,7 @@ class MemberServiceTest {
                 "AT",
                 "RT",
                 3600,
+                2_592_000,
                 "Bearer"
             ));
 
@@ -81,6 +82,7 @@ class MemberServiceTest {
                 "AT2",
                 "RT2",
                 3600,
+                2_592_000,
                 "Bearer"
             ));
 

--- a/src/test/java/gift/OrderServiceTest.java
+++ b/src/test/java/gift/OrderServiceTest.java
@@ -1,0 +1,229 @@
+package gift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import gift.dto.api.KakaoTokenResponseDto;
+import gift.dto.api.OrderRequestDto;
+import gift.dto.view.OrderViewResponseDto;
+import gift.entity.KakaoTokens;
+import gift.entity.Member;
+import gift.entity.Option;
+import gift.entity.Order;
+import gift.entity.Product;
+import gift.exception.InvalidMemberException;
+import gift.repository.OptionRepository;
+import gift.repository.OrderRepository;
+import gift.repository.WishRepository;
+import gift.service.KakaoMessageService;
+import gift.service.OptionService;
+import gift.service.OrderService;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OptionRepository optionRepository;
+
+    @Mock
+    private WishRepository wishRepository;
+
+    @Mock
+    private OptionService optionService;
+
+    @Mock
+    private KakaoMessageService kakaoMessageService;
+
+    @InjectMocks
+    private OrderService orderService;
+
+
+    KakaoTokenResponseDto dummyDto = new KakaoTokenResponseDto(
+        "dummy-access-token",
+        "dummy-refresh-token",
+        3600,
+        "Bearer"
+    );
+    private final Member member = new Member(1234L, "테스트유저", KakaoTokens.of(dummyDto));
+    private final Product product = new Product(1L, "초콜릿", 1000, "http://chocolate.png");
+    private final Option option = new Option(1L, product, "다크 초콜릿", 10);
+
+    @Test
+    @DisplayName("[성공] 주문 전체 조회 ( 주문 없음 ) - 200 OK")
+    void getOrderList_success_zero() {
+        Pageable pageable = PageRequest.of(0, 5, Sort.by("id").descending());
+        Page<Order> page = new PageImpl<>(List.of(), pageable, 0);
+        when(orderRepository.findByMemberId(member.getId(), pageable)).thenReturn(page);
+
+        Page<OrderViewResponseDto> result = orderService.getOrderListForMember(member, pageable);
+
+        assertThat(result.getTotalElements()).isZero();
+        verify(orderRepository).findByMemberId(member.getId(), pageable);
+    }
+
+    @Test
+    @DisplayName("[성공] 주문 전체 조회 ( 주문 1개 ) - 200 OK")
+    void getOrderList_success_one() {
+        Pageable pageable = PageRequest.of(0, 5, Sort.by("id").descending());
+        Order order = new Order(1, "msg", member, option);
+        Page<Order> page = new PageImpl<>(List.of(order), pageable, 1);
+        when(orderRepository.findByMemberId(member.getId(), pageable)).thenReturn(page);
+
+        Page<OrderViewResponseDto> result = orderService.getOrderListForMember(member, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().getFirst().quantity()).isEqualTo(1);
+        assertThat(result.getContent().getFirst().message()).isEqualTo("msg");
+        verify(orderRepository).findByMemberId(member.getId(), pageable);
+    }
+
+    @ParameterizedTest(name = "[page={0}] quantity={1}, message={2}")
+    @CsvSource({
+        // page, quantity, message, isFirst, hasPrevious, hasNext
+        "0, 3, C, true,  false, true",
+        "1, 2, B, false, true,  true",
+        "2, 1, A, false, true,  false"
+    })
+    @DisplayName("[성공] 주문 전체 조회 ( 주문 2개 이상 ) - 200 OK")
+    void getOrderList_success_multiple(
+        int pageIndex,
+        int expectedQuantity,
+        String expectedMessage,
+        boolean expectedFirst,
+        boolean expectedPrev,
+        boolean expectedNext
+    ) {
+        Order o1 = new Order(1, "A", member, option);
+        Order o2 = new Order(2, "B", member, option);
+        Order o3 = new Order(3, "C", member, option);
+        List<Order> allOrders = List.of(o3, o2, o1);
+
+        Pageable pageable = PageRequest.of(pageIndex, 1, Sort.by("id").descending());
+        List<Order> pageContent = allOrders.subList(pageIndex, pageIndex + 1);
+        Page<Order> stubPage = new PageImpl<>(pageContent, pageable, allOrders.size());
+
+        when(orderRepository.findByMemberId(member.getId(), pageable)).thenReturn(stubPage);
+
+        Page<OrderViewResponseDto> result = orderService.getOrderListForMember(member, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getTotalPages()).isEqualTo(3);
+        assertThat(result.getNumber()).isEqualTo(pageIndex);
+        assertThat(result.getSize()).isEqualTo(1);
+
+        assertThat(result.getContent())
+            .extracting(OrderViewResponseDto::quantity)
+            .containsExactly(expectedQuantity);
+        assertThat(result.getContent())
+            .extracting(OrderViewResponseDto::message)
+            .containsExactly(expectedMessage);
+
+        assertThat(result.isFirst()).isEqualTo(expectedFirst);
+        assertThat(result.hasPrevious()).isEqualTo(expectedPrev);
+        assertThat(result.hasNext()).isEqualTo(expectedNext);
+
+        verify(orderRepository).findByMemberId(member.getId(), pageable);
+    }
+
+    @Test
+    @DisplayName("[성공] 주문 추가 - 201 Created")
+    void addOrder_removesWish() {
+        OrderRequestDto dto = new OrderRequestDto(option.getId(), 2, "부탁해요");
+        when(optionRepository.findById(option.getId()))
+            .thenReturn(Optional.of(option));
+        Order saved = new Order(dto.getQuantity(), dto.getMessage(), member, option);
+        when(orderRepository.save(any(Order.class))).thenReturn(saved);
+        doNothing().when(kakaoMessageService)
+            .sendOrderMemo(any(Order.class), anyString());
+
+        Order result = orderService.addOrderForMember(member, dto);
+
+        assertThat(result.getQuantity()).isEqualTo(2);
+        assertThat(result.getMessage()).isEqualTo("부탁해요");
+        verify(optionService).subtractQuantity(option.getId(), 2);
+        verify(orderRepository).save(any(Order.class));
+        verify(wishRepository).deleteByMemberIdAndProductId(
+            member.getId(),
+            option.getProduct().getId()
+        );
+    }
+
+    @Test
+    @DisplayName("[실패] 주문 추가 - 옵션 없음 - 404 Not Found")
+    void addOrder_optionNotFound_throws() {
+        OrderRequestDto dto = new OrderRequestDto(999L, 2, "부탁해요");
+        when(optionRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> orderService.addOrderForMember(member, dto))
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessage("옵션을 찾을 수 없습니다.");
+
+        verify(optionService, never()).subtractQuantity(anyLong(), anyInt());
+        verify(orderRepository, never()).save(any());
+        verify(wishRepository, never()).deleteByMemberIdAndProductId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("[성공] 주문 삭제 - 204 No Content")
+    void deleteOrder_success() {
+        // given
+        Long orderId = 1L;
+        when(orderRepository.findById(orderId))
+            .thenReturn(Optional.of(new Order(1, "부탁해요", member, option)));
+
+        // when
+        orderService.deleteOrderForMember(member, orderId);
+
+        // then
+        verify(orderRepository).deleteById(orderId);
+    }
+
+    @Test
+    @DisplayName("[실패] 주문 삭제 - 주문 없음 - 404 Not Found")
+    void deleteOrder_orderNotFound_throws() {
+        Long orderId = 42L;
+        when(orderRepository.findById(orderId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> orderService.deleteOrderForMember(member, orderId))
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessage("주문을 찾을 수 없습니다.");
+
+        verify(orderRepository, never()).deleteById(anyLong());
+    }
+
+    @Test
+    @DisplayName("[실패] 공통 - 회원 없음 - 404 Not Found")
+    void anyMethod_nullMember_throwsInvalidMember() {
+        Pageable pageable = PageRequest.of(0, 1);
+        assertThatThrownBy(() -> orderService.getOrderListForMember(null, pageable))
+            .isInstanceOf(InvalidMemberException.class)
+            .hasMessage("유효하지 않은 회원입니다.");
+    }
+}

--- a/src/test/java/gift/OrderServiceTest.java
+++ b/src/test/java/gift/OrderServiceTest.java
@@ -69,9 +69,10 @@ public class OrderServiceTest {
         "dummy-access-token",
         "dummy-refresh-token",
         3600,
+        2_592_000,
         "Bearer"
     );
-    private final Member member = new Member(1234L, "테스트유저", KakaoTokens.of(dummyDto));
+    private final Member member = new Member(1234L, "테스트유저", KakaoTokens.from(dummyDto));
     private final Product product = new Product(1L, "초콜릿", 1000, "http://chocolate.png");
     private final Option option = new Option(1L, product, "다크 초콜릿", 10);
 

--- a/src/test/java/gift/OrderServiceTest.java
+++ b/src/test/java/gift/OrderServiceTest.java
@@ -193,15 +193,12 @@ public class OrderServiceTest {
     @Test
     @DisplayName("[성공] 주문 삭제 - 204 No Content")
     void deleteOrder_success() {
-        // given
         Long orderId = 1L;
         when(orderRepository.findById(orderId))
             .thenReturn(Optional.of(new Order(1, "부탁해요", member, option)));
 
-        // when
         orderService.deleteOrderForMember(member, orderId);
 
-        // then
         verify(orderRepository).deleteById(orderId);
     }
 

--- a/src/test/java/gift/WishControllerTest.java
+++ b/src/test/java/gift/WishControllerTest.java
@@ -11,6 +11,7 @@ import gift.exception.MissingAuthorizationHeaderException;
 import gift.repository.MemberRepository;
 import gift.repository.ProductRepository;
 import gift.service.WishService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,20 @@ public class WishControllerTest {
         given(loginMemberArgumentResolver.resolveArgument(any(), any(), any(), any()))
             .willAnswer(invocation -> {
                 NativeWebRequest req = invocation.getArgument(2);
+                String header = req.getHeader("Authorization");
+                if (header == null) {
+                    throw new MissingAuthorizationHeaderException("Authorization 헤더가 필요합니다.");
+                }
+                if (!header.startsWith("Bearer ")) {
+                    throw new InvalidAuthorizationHeaderException(
+                        "Authorization 헤더 형식이 올바르지 않습니다.");
+                }
+                return member;
+            });
+
+        given(loginMemberArgumentResolver.resolve(any(HttpServletRequest.class)))
+            .willAnswer(invocation -> {
+                HttpServletRequest req = invocation.getArgument(0);
                 String header = req.getHeader("Authorization");
                 if (header == null) {
                     throw new MissingAuthorizationHeaderException("Authorization 헤더가 필요합니다.");


### PR DESCRIPTION
### 구현 내용
- 주문하기 API 및 서비스 구현
  - 옵션(option) 조회 → 재고 차감 → 주문 저장 → 위시리스트 정리 로직
  - Spring Bean Validation(@Min, @Max) 적용 및 빈 메시지 허용 처리
- Thymeleaf 기반 주문 폼
  - 상품 상세 → /orders/form 이동, 옵션·수량 입력 후 주문
- 주문 내역 리스트(/orders) 및 상세(/orders/{id}) 페이지
  - 페이징(Pageable) 지원, Thymeleaf 테이블 렌더링
- 카카오톡 “나에게 보내기” 메모 API 연동
  - WebClient 설정 및 사용자 정의 템플릿(template_id + template_args) 호출
  - Member → KakaoTokens Embeddable로 토큰 관리, 토큰 만료 시 자동 갱신 지원
- 테스트 보강
  - 단위(Mock) 테스트 추가

---

### 주요 변경점
- Order, Option, Member 엔티티 리팩토링
- OrderRequestDto, OrderViewResponseDto 등 DTO 계층 보강
- Thymeleaf 뷰(order_form.html, order_list.html, order_success.html) 추가
- `.env` 에 `kakao.template-id` 추가
- 예외 처리: InsufficientStockException, ExternalServiceException 매핑 및 글로벌 핸들러

---

### 주문하기 기능 시연 영상

https://www.notion.so/Step2-23e75546dc3080e2a23af3ca2d663eef?source=copy_link

---

### 1단계 피드백 관련 답변

https://github.com/next-step/spring-gift-order/pull/91#discussion_r2232916323

https://github.com/next-step/spring-gift-order/pull/91#discussion_r2232914586

리뷰 부탁드립니다!!!