### PR TITLE
강원대 BE_고수림 - Step2

### DIFF
--- a/src/main/java/giftproject/auth/kakao/KakaoApiCaller.java
+++ b/src/main/java/giftproject/auth/kakao/KakaoApiCaller.java
@@ -1,0 +1,10 @@
+package giftproject.auth.kakao;
+
+import java.util.Map;
+
+public interface KakaoApiCaller {
+
+    String getKakaoAccessToken(String authrizationCode);
+
+    Map<String, Object> getKakaoUserInfo(String accessToken);
+}

--- a/src/main/java/giftproject/auth/kakao/KakaoApiRestClientImpl.java
+++ b/src/main/java/giftproject/auth/kakao/KakaoApiRestClientImpl.java
@@ -1,0 +1,68 @@
+package giftproject.auth.kakao;
+
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class KakaoApiRestClientImpl implements KakaoApiCaller {
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    private final RestClient kakaoAuthRestClient;
+    private final RestClient kakaoApiRestClient;
+
+    public KakaoApiRestClientImpl(RestClient.Builder restClientBuilder) {
+        this.kakaoAuthRestClient = restClientBuilder.baseUrl("https://kauth.kakao.com").build();
+        this.kakaoApiRestClient = restClientBuilder.baseUrl("https://kapi.kakao.com").build();
+    }
+
+    @Override
+    public String getKakaoAccessToken(String authorizationCode) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", authorizationCode);
+
+        Map<String, Object> responseBody = kakaoAuthRestClient.post()
+                .uri("/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {
+                });
+
+        return responseBody.get("access_token").toString();
+    }
+
+    @Override
+    public Map<String, Object> getKakaoUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+
+        Map<String, Object> responseBody = kakaoApiRestClient.get()
+                .uri("/v2/user/me")
+                .headers(httpHeaders -> httpHeaders.addAll(headers))
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        (request, response) -> {
+                            throw new RuntimeException("카카오 토큰 요청 실패");
+                        })
+                .body(Map.class);
+
+        return responseBody;
+    }
+
+}

--- a/src/main/java/giftproject/auth/kakao/KakaoAuthService.java
+++ b/src/main/java/giftproject/auth/kakao/KakaoAuthService.java
@@ -1,65 +1,22 @@
 package giftproject.auth.kakao;
 
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClient;
 
 @Service
 public class KakaoAuthService {
 
-    @Value("${kakao.client-id}")
-    private String clientId;
+    private final KakaoApiCaller kakaoApiCaller;
 
-    @Value("${kakao.redirect-uri}")
-    private String redirectUri;
-
-    private final RestClient kakaoAuthRestClient;
-    private final RestClient kakaoApiRestClient;
-
-    public KakaoAuthService(RestClient.Builder restClientBuilder) {
-        this.kakaoAuthRestClient = restClientBuilder.baseUrl("https://kauth.kakao.com").build();
-        this.kakaoApiRestClient = restClientBuilder.baseUrl("https://kapi.kakao.com").build();
+    public KakaoAuthService(KakaoApiCaller kakaoApiCaller) {
+        this.kakaoApiCaller = kakaoApiCaller;
     }
 
     public String getKakaoAccessToken(String authorizationCode) {
-        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("grant_type", "authorization_code");
-        body.add("client_id", clientId);
-        body.add("redirect_uri", redirectUri);
-        body.add("code", authorizationCode);
-
-        Map<String, Object> responseBody = kakaoAuthRestClient.post()
-                .uri("/oauth/token")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(body)
-                .retrieve()
-                .body(new ParameterizedTypeReference<>() {
-                });
-
-        return responseBody.get("access_token").toString();
+        return kakaoApiCaller.getKakaoAccessToken(authorizationCode);
     }
 
     public Map<String, Object> getKakaoUserInfo(String accessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-
-        Map<String, Object> responseBody = kakaoApiRestClient.get()
-                .uri("/v2/user/me")
-                .headers(httpHeaders -> httpHeaders.addAll(headers))
-                .retrieve()
-                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
-                        (request, response) -> {
-                            throw new RuntimeException("카카오 토큰 요청 실패");
-                        })
-                .body(Map.class);
-
-        return responseBody;
+        return kakaoApiCaller.getKakaoUserInfo(accessToken);
     }
 }

--- a/src/main/java/giftproject/auth/kakao/KakaoLoginController.java
+++ b/src/main/java/giftproject/auth/kakao/KakaoLoginController.java
@@ -2,6 +2,8 @@ package giftproject.auth.kakao;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class KakaoLoginController {
+
+    private static final Logger log = LoggerFactory.getLogger(KakaoLoginController.class);
 
     private final KakaoAuthService kakaoAuthService;
 
@@ -24,10 +28,10 @@ public class KakaoLoginController {
 
         try {
             String accessToken = kakaoAuthService.getKakaoAccessToken(authorizaionCode);
-            System.out.println("액세스 토큰 발급 성공: " + accessToken);
+            log.info("액세스 토큰 발급 성공: {}", accessToken);
 
             Map<String, Object> userInfo = kakaoAuthService.getKakaoUserInfo(accessToken);
-            System.out.println("사용자 정보: " + userInfo);
+            log.info("사용자 정보: {}", userInfo);
 
             response.put("status", "SUCCESS");
             response.put("message", "사용자 정보 획득 성공");

--- a/src/main/java/giftproject/auth/kakao/KakaoLoginController.java
+++ b/src/main/java/giftproject/auth/kakao/KakaoLoginController.java
@@ -1,5 +1,8 @@
 package giftproject.auth.kakao;
 
+import giftproject.member.entity.Member;
+import giftproject.member.service.MemberService;
+import giftproject.member.util.JwtTokenProvider;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -16,9 +19,14 @@ public class KakaoLoginController {
     private static final Logger log = LoggerFactory.getLogger(KakaoLoginController.class);
 
     private final KakaoAuthService kakaoAuthService;
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public KakaoLoginController(KakaoAuthService kakaoAuthService) {
+    public KakaoLoginController(KakaoAuthService kakaoAuthService, MemberService memberService,
+            JwtTokenProvider jwtTokenProvider) {
         this.kakaoAuthService = kakaoAuthService;
+        this.memberService = memberService;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @GetMapping
@@ -31,12 +39,19 @@ public class KakaoLoginController {
             log.info("액세스 토큰 발급 성공: {}", accessToken);
 
             Map<String, Object> userInfo = kakaoAuthService.getKakaoUserInfo(accessToken);
+            Long kakaoId = (Long) userInfo.get("id");
+            Map<String, Object> kakaoAccount = (Map<String, Object>) userInfo.get("kakao_account");
             log.info("사용자 정보: {}", userInfo);
+            String email = null;
+            Member member = memberService.saveOrUpdateKakaoAccessTokenForMember(kakaoId, email,
+                    accessToken);
+
+            String ourServiceJwt = jwtTokenProvider.generateToken(member.getId());
 
             response.put("status", "SUCCESS");
-            response.put("message", "사용자 정보 획득 성공");
-            response.put("accessToken", accessToken);
-            response.put("userInfo", userInfo);
+            response.put("message", "카카오 로그인 및 회원 정보 연동 성공");
+            response.put("ourServiceJwt", ourServiceJwt);
+            response.put("memberId", member.getId());
 
             return new ResponseEntity<>(response, HttpStatus.OK);
         } catch (Exception e) {

--- a/src/main/java/giftproject/auth/kakao/KakaoLoginController.java
+++ b/src/main/java/giftproject/auth/kakao/KakaoLoginController.java
@@ -40,7 +40,6 @@ public class KakaoLoginController {
 
             Map<String, Object> userInfo = kakaoAuthService.getKakaoUserInfo(accessToken);
             Long kakaoId = (Long) userInfo.get("id");
-            Map<String, Object> kakaoAccount = (Map<String, Object>) userInfo.get("kakao_account");
             log.info("사용자 정보: {}", userInfo);
             String email = null;
             Member member = memberService.saveOrUpdateKakaoAccessTokenForMember(kakaoId, email,

--- a/src/main/java/giftproject/member/entity/Member.java
+++ b/src/main/java/giftproject/member/entity/Member.java
@@ -22,11 +22,17 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column
     private String email;
 
-    @Column(nullable = false)
+    @Column
     private String password;
+
+    @Column(name = "kakao_access_token")
+    private String kakaoAccessToken;
+
+    @Column(name = "kakao_id", unique = true)
+    private Long kakaoId;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Wish> wishes = new ArrayList<>();
@@ -40,8 +46,20 @@ public class Member {
         this.password = password;
     }
 
+    public Member(Long id, String email, String password, String kakaoAccessToken, Long kakaoId) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.kakaoAccessToken = kakaoAccessToken;
+        this.kakaoId = kakaoId;
+    }
+
     public Member(String email, String password) {
-        this(null, email, password);
+        this(null, email, password, null, null);
+    }
+
+    public Member(String email, String kakaoAccessToken, Long kakaoId) {
+        this(null, email, null, kakaoAccessToken, kakaoId);
     }
 
     public Long getId() {
@@ -58,6 +76,18 @@ public class Member {
 
     public List<Wish> getWishes() {
         return wishes;
+    }
+
+    public String getKakaoAccessToken() {
+        return kakaoAccessToken;
+    }
+
+    public Long getKakaoId() {
+        return kakaoId;
+    }
+
+    public void setKakaoAccessToken(String kakaoAccessToken) {
+        this.kakaoAccessToken = kakaoAccessToken;
     }
 
     public void update(String email, String password) {

--- a/src/main/java/giftproject/member/entity/Member.java
+++ b/src/main/java/giftproject/member/entity/Member.java
@@ -114,6 +114,7 @@ public class Member {
         return "Member{" +
                 "id=" + id +
                 ", email='" + email + '\'' +
+                ", kakaoId='" + kakaoId +
                 '}';
     }
 

--- a/src/main/java/giftproject/member/repository/MemberRepository.java
+++ b/src/main/java/giftproject/member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByKakaoId(Long kakaoId);
 }

--- a/src/main/java/giftproject/member/service/MemberService.java
+++ b/src/main/java/giftproject/member/service/MemberService.java
@@ -7,6 +7,7 @@ import giftproject.member.repository.MemberRepository;
 import giftproject.member.util.JwtTokenProvider;
 import giftproject.member.util.PasswordEncoder;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -34,7 +35,7 @@ public class MemberService {
         Member newMember = new Member(requestDto.email(), encodedPassword);
         Member savedMember = memberRepository.save(newMember);
 
-        return jwtTokenProvider.generateToken(savedMember.getId(), savedMember.getEmail());
+        return jwtTokenProvider.generateToken(savedMember.getId());
     }
 
     @Transactional(readOnly = true)
@@ -48,7 +49,22 @@ public class MemberService {
                     "이메일 또는 비밀번호가 일치하지 않습니다.");
         }
 
-        return jwtTokenProvider.generateToken(member.getId(), member.getEmail());
+        return jwtTokenProvider.generateToken(member.getId());
+    }
+
+    @Transactional
+    public Member saveOrUpdateKakaoAccessTokenForMember(Long kakaoId, String email,
+            String kakaoAccessToken) {
+        Optional<Member> existingMember = memberRepository.findByKakaoId(kakaoId);
+
+        Member member;
+        if (existingMember.isPresent()) {
+            member = existingMember.get();
+            member.setKakaoAccessToken(kakaoAccessToken);
+        } else {
+            member = new Member(email, kakaoAccessToken, kakaoId);
+        }
+        return memberRepository.save(member);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/giftproject/member/util/JwtTokenProvider.java
+++ b/src/main/java/giftproject/member/util/JwtTokenProvider.java
@@ -28,13 +28,12 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 
-    public String generateToken(Long memberId, String email) {
+    public String generateToken(Long memberId) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + expirationTime);
 
         return Jwts.builder()
                 .setSubject(memberId.toString())
-                .claim("email", email)
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)

--- a/src/main/java/giftproject/option/entity/Option.java
+++ b/src/main/java/giftproject/option/entity/Option.java
@@ -70,10 +70,6 @@ public class Option {
         return product;
     }
 
-    public Long setId(Long id) {
-        return id;
-    }
-
     public String getOptionType() {
         return optionType;
     }

--- a/src/main/java/giftproject/order/controller/OrderController.java
+++ b/src/main/java/giftproject/order/controller/OrderController.java
@@ -1,0 +1,35 @@
+package giftproject.order.controller;
+
+import giftproject.member.annotation.LoginMember;
+import giftproject.member.entity.Member;
+import giftproject.order.dto.OrderRequestDto;
+import giftproject.order.dto.OrderResponseDto;
+import giftproject.order.service.OrderService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @PostMapping
+    public ResponseEntity<OrderResponseDto> create(
+            @Valid @RequestBody OrderRequestDto requestDto,
+            @LoginMember Member member) {
+        OrderResponseDto response = orderService.create(requestDto, member.getId());
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/giftproject/order/dto/OrderRequestDto.java
+++ b/src/main/java/giftproject/order/dto/OrderRequestDto.java
@@ -1,0 +1,19 @@
+package giftproject.order.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record OrderRequestDto(
+        @NotNull(message = "옵션 ID는 필수입니다.")
+        Long optionId,
+
+        @NotNull(message = "수량은 필수입니다.")
+        @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+        int quantity,
+
+        @Size(max = 500, message = "메시지는 500자를 초과할 수 없습니다.")
+        String message
+) {
+
+}

--- a/src/main/java/giftproject/order/dto/OrderResponseDto.java
+++ b/src/main/java/giftproject/order/dto/OrderResponseDto.java
@@ -1,0 +1,23 @@
+package giftproject.order.dto;
+
+import giftproject.order.entity.Order;
+import java.time.LocalDateTime;
+
+public record OrderResponseDto(
+        Long id,
+        Long optionId,
+        int quantity,
+        LocalDateTime orderDateTime,
+        String message
+) {
+
+    public static OrderResponseDto from(Order order) {
+        return new OrderResponseDto(
+                order.getId(),
+                order.getOptionId(),
+                order.getQuantity(),
+                order.getOrderDateTime(),
+                order.getMessage()
+        );
+    }
+}

--- a/src/main/java/giftproject/order/entity/Order.java
+++ b/src/main/java/giftproject/order/entity/Order.java
@@ -1,0 +1,73 @@
+package giftproject.order.entity;
+
+import giftproject.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "option_id", nullable = false)
+    private Long optionId;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(nullable = false)
+    private LocalDateTime orderDateTime;
+
+    @Column(length = 500)
+    private String message;
+
+    protected Order() {
+    }
+
+    public Order(Member member, Long optionId, int quantity, LocalDateTime orderDateTime,
+            String message) {
+        this.member = member;
+        this.optionId = optionId;
+        this.quantity = quantity;
+        this.orderDateTime = LocalDateTime.now();
+        this.message = message;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Long getOptionId() {
+        return optionId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public LocalDateTime getOrderDateTime() {
+        return orderDateTime;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/giftproject/order/repository/OrderRepository.java
+++ b/src/main/java/giftproject/order/repository/OrderRepository.java
@@ -1,0 +1,10 @@
+package giftproject.order.repository;
+
+import giftproject.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+}

--- a/src/main/java/giftproject/order/service/KakaoMessageCaller.java
+++ b/src/main/java/giftproject/order/service/KakaoMessageCaller.java
@@ -1,0 +1,9 @@
+package giftproject.order.service;
+
+import java.util.Map;
+import org.springframework.util.MultiValueMap;
+
+public interface KakaoMessageCaller {
+
+    <T> Map<String, Object> post(String url, String authorization, MultiValueMap<String, T> body);
+}

--- a/src/main/java/giftproject/order/service/KakaoMessageCallerImpl.java
+++ b/src/main/java/giftproject/order/service/KakaoMessageCallerImpl.java
@@ -1,0 +1,34 @@
+package giftproject.order.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class KakaoMessageCallerImpl implements KakaoMessageCaller {
+
+    private final RestClient restClient;
+
+    public KakaoMessageCallerImpl(RestClient.Builder restClientBuilder) {
+        this.restClient = restClientBuilder.build();
+    }
+
+    @Override
+    public <T> Map<String, Object> post(String url, String authorization,
+            MultiValueMap<String, T> body) {
+        return restClient.post()
+                .uri(url)
+                .header("Authorization", "Bearer " + authorization)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        (request, response) -> {
+                            throw new RuntimeException("카카오 메시지 전송 실패");
+                        })
+                .body(new HashMap<String, Object>().getClass());
+    }
+}

--- a/src/main/java/giftproject/order/service/KakaoMessageService.java
+++ b/src/main/java/giftproject/order/service/KakaoMessageService.java
@@ -1,0 +1,8 @@
+package giftproject.order.service;
+
+import giftproject.order.entity.Order;
+
+public interface KakaoMessageService {
+
+    boolean sendOrderCompletionMessageToMe(String KaKaoAccessToken, Order order, String message);
+}

--- a/src/main/java/giftproject/order/service/KakaoMessageServiceImpl.java
+++ b/src/main/java/giftproject/order/service/KakaoMessageServiceImpl.java
@@ -1,0 +1,89 @@
+package giftproject.order.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import giftproject.order.entity.Order;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class KakaoMessageServiceImpl implements KakaoMessageService {
+
+    private static final Logger log = LoggerFactory.getLogger(KakaoMessageServiceImpl.class);
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    private String memoUrl = "https://kapi.kakao.com/v2/api/talk/memo/default/send";
+
+    public KakaoMessageServiceImpl(RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public boolean sendOrderCompletionMessageToMe(String kakaoAccessToken, Order order,
+            String customMessage) {
+        String messageText = createMessageText(order, customMessage);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("object_type", "text");
+        body.put("text", messageText);
+        body.put("link", new HashMap<String, String>() {{
+            put("web_url", "http://localhost:8080");
+            put("mobile_web_url", "http://localhost:8080");
+        }});
+        body.put("button_title", "주문 내역 확인");
+
+        String templateObjectJson;
+        try {
+            templateObjectJson = objectMapper.writeValueAsString(body);
+        } catch (Exception e) {
+            log.error("메시지 템플릿 JSON 변환 실패: {}", e.getMessage());
+            return false;
+        }
+
+        MultiValueMap<String, Object> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("template_object", templateObjectJson);
+
+        try {
+            Map<String, Object> kakaoResponse = restClient.post()
+                    .uri(memoUrl)
+                    .header("Authorization", "Bearer " + kakaoAccessToken)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(requestBody)
+                    .retrieve()
+                    .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                            (request, response) -> {
+                                throw new RuntimeException("카카오 메시지 전송 실패");
+                            })
+                    .body(new HashMap<String, Object>().getClass());
+            return true;
+        } catch (Exception e) {
+            log.error("카카오톡 메시지 전송 중 예외 발생: {}", e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private String createMessageText(Order order, String customMessage) {
+        StringBuilder messageText = new StringBuilder();
+        messageText.append("주문 완료!\n\n");
+        messageText.append("주문 번호: ").append(order.getId()).append("\n");
+        messageText.append("옵션 ID: ").append(order.getOptionId()).append("\n");
+        messageText.append("수량: ").append(order.getQuantity()).append("\n");
+        messageText.append("주문 일시: ").append(order.getOrderDateTime()
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))).append("\n");
+        if (customMessage != null && !customMessage.isEmpty()) {
+            messageText.append("메시지: ").append(customMessage).append("\n");
+        }
+        return messageText.toString();
+    }
+}

--- a/src/main/java/giftproject/order/service/KakaoMessageServiceImpl.java
+++ b/src/main/java/giftproject/order/service/KakaoMessageServiceImpl.java
@@ -1,5 +1,6 @@
 package giftproject.order.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import giftproject.order.entity.Order;
 import java.time.format.DateTimeFormatter;
@@ -7,31 +8,46 @@ import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClient;
 
 @Service
 public class KakaoMessageServiceImpl implements KakaoMessageService {
 
     private static final Logger log = LoggerFactory.getLogger(KakaoMessageServiceImpl.class);
 
-    private final RestClient restClient;
+    private final KakaoMessageCaller kakaoMessageCaller;
     private final ObjectMapper objectMapper;
+    private final String memoUrl;
 
-    private String memoUrl = "https://kapi.kakao.com/v2/api/talk/memo/default/send";
-
-    public KakaoMessageServiceImpl(RestClient.Builder restClientBuilder,
-            ObjectMapper objectMapper) {
-        this.restClient = restClientBuilder.build();
+    public KakaoMessageServiceImpl(KakaoMessageCaller kakaoMessageCaller,
+            ObjectMapper objectMapper, @Value("${kakao.send-memo-url}") String memoUrl) {
+        this.kakaoMessageCaller = kakaoMessageCaller;
         this.objectMapper = objectMapper;
+        this.memoUrl = memoUrl;
     }
 
     @Override
     public boolean sendOrderCompletionMessageToMe(String kakaoAccessToken, Order order,
             String customMessage) {
+        try {
+            String templateObjectJson = createTemplateObject(order, customMessage);
+            MultiValueMap<String, Object> requestBody = new LinkedMultiValueMap<>();
+            requestBody.add("template_object", templateObjectJson);
+
+            kakaoMessageCaller.post(memoUrl, kakaoAccessToken, requestBody);
+
+            return true;
+        } catch (Exception e) {
+            log.error("메시지 템플릿 JSON 변환 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private String createTemplateObject(Order order, String customMessage)
+            throws JsonProcessingException {
         String messageText = createMessageText(order, customMessage);
 
         Map<String, Object> body = new HashMap<>();
@@ -43,34 +59,7 @@ public class KakaoMessageServiceImpl implements KakaoMessageService {
         }});
         body.put("button_title", "주문 내역 확인");
 
-        String templateObjectJson;
-        try {
-            templateObjectJson = objectMapper.writeValueAsString(body);
-        } catch (Exception e) {
-            log.error("메시지 템플릿 JSON 변환 실패: {}", e.getMessage());
-            return false;
-        }
-
-        MultiValueMap<String, Object> requestBody = new LinkedMultiValueMap<>();
-        requestBody.add("template_object", templateObjectJson);
-
-        try {
-            Map<String, Object> kakaoResponse = restClient.post()
-                    .uri(memoUrl)
-                    .header("Authorization", "Bearer " + kakaoAccessToken)
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .body(requestBody)
-                    .retrieve()
-                    .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
-                            (request, response) -> {
-                                throw new RuntimeException("카카오 메시지 전송 실패");
-                            })
-                    .body(new HashMap<String, Object>().getClass());
-            return true;
-        } catch (Exception e) {
-            log.error("카카오톡 메시지 전송 중 예외 발생: {}", e.getMessage(), e);
-            return false;
-        }
+        return objectMapper.writeValueAsString(body);
     }
 
     private String createMessageText(Order order, String customMessage) {

--- a/src/main/java/giftproject/order/service/OrderService.java
+++ b/src/main/java/giftproject/order/service/OrderService.java
@@ -1,0 +1,60 @@
+package giftproject.order.service;
+
+import giftproject.member.entity.Member;
+import giftproject.member.repository.MemberRepository;
+import giftproject.option.entity.Option;
+import giftproject.option.repository.OptionRepository;
+import giftproject.order.dto.OrderRequestDto;
+import giftproject.order.dto.OrderResponseDto;
+import giftproject.order.entity.Order;
+import giftproject.order.repository.OrderRepository;
+import giftproject.wishlist.repository.WishRepository;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final OptionRepository optionRepository;
+    private final WishRepository wishRepository;
+    private final MemberRepository memberRepository;
+
+    public OrderService(OrderRepository orderRepository,
+            OptionRepository optionRepository,
+            WishRepository wishRepository, MemberRepository memberRepository) {
+        this.orderRepository = orderRepository;
+        this.optionRepository = optionRepository;
+        this.wishRepository = wishRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public OrderResponseDto create(OrderRequestDto request, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NoSuchElementException("해당 회원을 찾을 수 없습니다: " + memberId));
+
+        Option option = optionRepository.findById(request.optionId())
+                .orElseThrow(() -> new NoSuchElementException(
+                        "해당 상품 옵션을 찾을 수 없습니다: " + request.optionId()));
+
+        option.subtractQuantity(request.quantity());
+        optionRepository.save(option);
+
+        wishRepository.findByMemberIdAndProductId(memberId, request.optionId())
+                .ifPresent(wishRepository::delete);
+
+        Order newOrder = new Order(
+                member,
+                request.optionId(),
+                request.quantity(),
+                LocalDateTime.now(),
+                request.message()
+        );
+        Order savedOrder = orderRepository.save(newOrder);
+
+        return OrderResponseDto.from(savedOrder);
+    }
+}

--- a/src/main/java/giftproject/order/service/OrderService.java
+++ b/src/main/java/giftproject/order/service/OrderService.java
@@ -12,23 +12,29 @@ import giftproject.wishlist.repository.WishRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class OrderService {
 
+    private static final Logger log = LoggerFactory.getLogger(KakaoMessageServiceImpl.class);
     private final OrderRepository orderRepository;
     private final OptionRepository optionRepository;
     private final WishRepository wishRepository;
     private final MemberRepository memberRepository;
+    private final KakaoMessageServiceImpl kakaoMessageService;
 
     public OrderService(OrderRepository orderRepository,
             OptionRepository optionRepository,
-            WishRepository wishRepository, MemberRepository memberRepository) {
+            WishRepository wishRepository, MemberRepository memberRepository,
+            KakaoMessageServiceImpl kakaoMessageService) {
         this.orderRepository = orderRepository;
         this.optionRepository = optionRepository;
         this.wishRepository = wishRepository;
         this.memberRepository = memberRepository;
+        this.kakaoMessageService = kakaoMessageService;
     }
 
     @Transactional
@@ -54,6 +60,18 @@ public class OrderService {
                 request.message()
         );
         Order savedOrder = orderRepository.save(newOrder);
+
+        String kakaoAccessToken = member.getKakaoAccessToken();
+        boolean isSent = kakaoMessageService.sendOrderCompletionMessageToMe(
+                kakaoAccessToken,
+                savedOrder,
+                request.message()
+        );
+        if (isSent) {
+            log.info("카카오톡 주문 완료 메시지 전송 성공");
+        } else {
+            log.warn("카카오톡 주문 완료 메시지 전송 실패");
+        }
 
         return OrderResponseDto.from(savedOrder);
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,18 @@
+INSERT INTO products (name, price, image_url)
+VALUES ('스타벅스 아메리카노 Tall', 4500, 'image.com');
+INSERT INTO products (name, price, image_url)
+VALUES ('배스킨라빈스 파인트', 8900, 'image.com');
+INSERT INTO products (name, price, image_url)
+VALUES ('교촌치킨 허니콤보', 20000, 'image.com');
+INSERT INTO product_option (product_id, option_type, option_value, quantity)
+VALUES (1, 'HOT/ICE', 'HOT', 2000);
+INSERT INTO product_option (product_id, option_type, option_value, quantity)
+VALUES (1, 'HOT/ICE', 'ICE', 2000);
+INSERT INTO product_option (product_id, option_type, option_value, quantity)
+VALUES (1, '샷', '샷 추가', 500);
+INSERT INTO product_option (product_id, option_type, option_value, quantity)
+VALUES (2, 'size', '싱글레귤러', 500);
+INSERT INTO product_option (product_id, option_type, option_value, quantity)
+VALUES (2, 'size', '더블주니어', 2000);
+INSERT INTO product_option (product_id, option_type, option_value, quantity)
+VALUES (3, 'size', '순살 변경', 3000);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -7,8 +7,10 @@ CREATE TABLE IF NOT EXISTS products (
 
 CREATE TABLE IF NOT EXISTS members (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    email VARCHAR(255) NOT NULL UNIQUE,
-    password VARCHAR(255) NOT NULL
+    email VARCHAR(255),
+    password VARCHAR(255),
+    kakao_access_token VARCHAR(500),
+    kakao_id BIGINT UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS wishes (
@@ -30,3 +32,23 @@ CREATE TABLE IF NOT EXISTS product_option (
     UNIQUE (product_id, option_type, option_value),
     FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS orders (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id BIGINT NOT NULL,
+    option_id BIGINT NOT NULL,
+    quantity INT NOT NULL,
+    orderDateTime DATETIME NOT NULL,
+    message VARCHAR(500),
+    FOREIGN KEY (member_id) REFERENCES members(id)
+);
+
+INSERT INTO products (name, price, image_url) VALUES ('스타벅스 아메리카노 Tall', 4500, 'image.com');
+INSERT INTO products (name, price, image_url) VALUES ('배스킨라빈스 파인트', 8900, 'image.com');
+INSERT INTO products (name, price, image_url) VALUES ('교촌치킨 허니콤보', 20000, 'image.com');
+INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (1, 'HOT/ICE', 'HOT', 2000);
+INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (1, 'HOT/ICE', 'ICE', 2000);
+INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (1, '샷', '샷 추가', 500);
+INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (2, 'size', '싱글레귤러', 500);
+INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (2, 'size', '더블주니어', 2000);
+INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (3, 'size', '순살 변경', 3000);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -42,13 +42,3 @@ CREATE TABLE IF NOT EXISTS orders (
     message VARCHAR(500),
     FOREIGN KEY (member_id) REFERENCES members(id)
 );
-
-INSERT INTO products (name, price, image_url) VALUES ('스타벅스 아메리카노 Tall', 4500, 'image.com');
-INSERT INTO products (name, price, image_url) VALUES ('배스킨라빈스 파인트', 8900, 'image.com');
-INSERT INTO products (name, price, image_url) VALUES ('교촌치킨 허니콤보', 20000, 'image.com');
-INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (1, 'HOT/ICE', 'HOT', 2000);
-INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (1, 'HOT/ICE', 'ICE', 2000);
-INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (1, '샷', '샷 추가', 500);
-INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (2, 'size', '싱글레귤러', 500);
-INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (2, 'size', '더블주니어', 2000);
-INSERT INTO product_option (product_id, option_type, option_value, quantity) VALUES (3, 'size', '순살 변경', 3000);


### PR DESCRIPTION
안녕하세요. 강원대 BE_고수림입니다. 리뷰 요청드립니다!

### 구현한 기능 
order
- 수령인에게 보낼 메시지 작성
- 해당 상품 옵션 수량 차감
- 위시 리스트에서 삭제

MessageService
- 메시지 api 사용
</br>

- jwt 토큰도 함께 발급 받을 수 있도록 변경
- member에 kakao_id, kakao_token 저장
---
### 리뷰 요청 사항
로그인 방법이 다양할 때 사용자 정보와 토큰을 어떻게 관리해야하는지 잘 모르겠습니다. 

이번 과제를 하면서 기존의 도메인들은 member에 매핑 되어있기 때문에 카카오 사용자 정보를 기존의 member에 저장해서 관리해야겠다고 생각하게 되었습니다. 또 카카오 api를 사용할 때는 카카오 토큰이, 기존의 기능들에는 jwt 가 필요한 상황이라 카카오 로그인 시 jwt도 함께 발급받도록 했습니다.

그런데 이렇게 구현하면 기존 사용자 정보였던 member email, password에 null을 허용하게 되고 데이터 무결성이나 일관성 저해될 것 같다는 생각이 들었습니다. 이러한 상황에서 사용자 정보와 토큰을 관리하는 더 좋은 방법이 있는지 멘토님께 여쭤보고 싶습니다.

감사합니다!