### PR TITLE
강원대 BE_이시행 2단계 - 주문하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ KakaoAuth용 RestTemplate 정의
 @JsonProperty를 사용하여 Camel case 코드 컨벤션 유지
 
 외부 API 호출 레이어 service → repository(infrastructure) 변경
+
+# 주문하기
+1. Wish, Product, Option, ProductOption 테이블 간의 연관관계 재정립
+2. KakaoToken 테이블 생성 후 User와 1:1 참조하도록 추가
+3. User가 자신의 위시리스트를 볼 수 있도록 Wish와 연관관계 형성
+4. 주문하기 로직 및 카카오 메세지 전송 기능 구현

--- a/src/main/java/gift/configuration/AppConfig.java
+++ b/src/main/java/gift/configuration/AppConfig.java
@@ -3,8 +3,6 @@ package gift.configuration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
@@ -14,12 +12,10 @@ public class AppConfig {
 
     // 카카오 인증 관련 API 요청 템플릿
     @Bean
-    public RestTemplate KaKaoAuthRestTemplate(RestTemplateBuilder builder) {
+    public RestTemplate kakaoAuthRestTemplate(RestTemplateBuilder builder) {
         return builder
-                .rootUri("https://kauth.kakao.com/oauth")
                 .connectTimeout(Duration.ofSeconds(10))
                 .readTimeout(Duration.ofSeconds(10))
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .build();
     }
 }

--- a/src/main/java/gift/configuration/AppConfig.java
+++ b/src/main/java/gift/configuration/AppConfig.java
@@ -14,8 +14,19 @@ public class AppConfig {
     @Bean
     public RestTemplate kakaoAuthRestTemplate(RestTemplateBuilder builder) {
         return builder
-                .connectTimeout(Duration.ofSeconds(10))
-                .readTimeout(Duration.ofSeconds(10))
+                .rootUri("https://kauth.kakao.com")
+                .connectTimeout(Duration.ofSeconds(5))
+                .readTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    // 카카오 토큰으로 불러오는 API 요청 템플릿
+    @Bean
+    public RestTemplate kakaoKapiRestTemplate(RestTemplateBuilder builder) {
+        return builder
+                .rootUri("https://kapi.kakao.com")
+                .connectTimeout(Duration.ofSeconds(3))
+                .readTimeout(Duration.ofSeconds(3))
                 .build();
     }
 }

--- a/src/main/java/gift/controller/KakaoAuthController.java
+++ b/src/main/java/gift/controller/KakaoAuthController.java
@@ -1,7 +1,9 @@
 package gift.controller;
 
+import gift.annotation.UserValid;
 import gift.dto.KakaoTokenDto;
 import gift.dto.KakaoUserInfoDto;
+import gift.dto.UserInfoDto;
 import gift.service.KakaoAuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +17,16 @@ public class KakaoAuthController {
         this.kakaoAuthService = kakaoAuthService;
     }
 
+
     /**
-     *
-     * @param code 사용자 인가 코드
-     * @return KakaoTokenDto 카카오가 발급한 토큰
+     * 기존 회원정보에 카카오 토큰 연동하는 API
+     * @param userInfoDto 기존 사용자 정보
+     * @param code 카카오 사용자 인가 정보
+     * @return KakaoTokenDto 카카오 토큰
      */
     @GetMapping
-    public ResponseEntity<KakaoTokenDto> getKakaoToken(@RequestParam("code") String code) {
-        return new ResponseEntity<> (kakaoAuthService.getKakaoToken(code), HttpStatus.OK);
+    public ResponseEntity<KakaoTokenDto> accessKakaoToken(@UserValid UserInfoDto userInfoDto, @RequestParam("code") String code) {
+        return new ResponseEntity<> (kakaoAuthService.accessKakaoToken(userInfoDto, code), HttpStatus.OK);
     }
 
     @GetMapping("/kakao-info")

--- a/src/main/java/gift/controller/KakaoAuthController.java
+++ b/src/main/java/gift/controller/KakaoAuthController.java
@@ -29,6 +29,12 @@ public class KakaoAuthController {
         return new ResponseEntity<> (kakaoAuthService.accessKakaoToken(userInfoDto, code), HttpStatus.OK);
     }
 
+
+    /**
+     * 내 유저 정보에 저장돼있는 카카오 토큰으로 카카오 유저 정보 받아오는 API
+     * @param userInfoDto 유저 정보
+     * @return 카카오 유저 정보
+     */
     @GetMapping("/kakao-info")
     public ResponseEntity<KakaoUserInfoDto> getKakaoUserInfo(@UserValid UserInfoDto userInfoDto) {
         return new ResponseEntity<>(kakaoAuthService.getKakaoUserInfo(userInfoDto), HttpStatus.OK);

--- a/src/main/java/gift/controller/KakaoAuthController.java
+++ b/src/main/java/gift/controller/KakaoAuthController.java
@@ -30,7 +30,7 @@ public class KakaoAuthController {
     }
 
     @GetMapping("/kakao-info")
-    public ResponseEntity<KakaoUserInfoDto> getKakaoUserInfo(@RequestBody KakaoTokenDto kakaoTokenDto) {
-        return new ResponseEntity<>(kakaoAuthService.getKakaoUserInfo(kakaoTokenDto), HttpStatus.OK);
+    public ResponseEntity<KakaoUserInfoDto> getKakaoUserInfo(@UserValid UserInfoDto userInfoDto) {
+        return new ResponseEntity<>(kakaoAuthService.getKakaoUserInfo(userInfoDto), HttpStatus.OK);
     }
 }

--- a/src/main/java/gift/controller/KakaoOrderController.java
+++ b/src/main/java/gift/controller/KakaoOrderController.java
@@ -1,0 +1,25 @@
+package gift.controller;
+
+import gift.annotation.UserValid;
+import gift.dto.KakaoOrderRequestDto;
+import gift.dto.UserInfoDto;
+import gift.service.KakaoOrderService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/kakao-order")
+public class KakaoOrderController {
+    private final KakaoOrderService kakaoOrderService;
+    public KakaoOrderController(KakaoOrderService kakaoOrderService) {
+        this.kakaoOrderService = kakaoOrderService;
+    }
+
+    public ResponseEntity<Void> order(@UserValid UserInfoDto userInfoDto, KakaoOrderRequestDto kakaoOrderRequestDto) {
+        kakaoOrderService.orderProduct(userInfoDto, kakaoOrderRequestDto);
+        return ResponseEntity.noContent().build();
+    }
+
+
+}

--- a/src/main/java/gift/controller/KakaoOrderController.java
+++ b/src/main/java/gift/controller/KakaoOrderController.java
@@ -5,6 +5,8 @@ import gift.dto.KakaoOrderRequestDto;
 import gift.dto.UserInfoDto;
 import gift.service.KakaoOrderService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,7 +18,8 @@ public class KakaoOrderController {
         this.kakaoOrderService = kakaoOrderService;
     }
 
-    public ResponseEntity<Void> order(@UserValid UserInfoDto userInfoDto, KakaoOrderRequestDto kakaoOrderRequestDto) {
+    @PostMapping
+    public ResponseEntity<Void> order(@UserValid UserInfoDto userInfoDto, @RequestBody KakaoOrderRequestDto kakaoOrderRequestDto) {
         kakaoOrderService.orderProduct(userInfoDto, kakaoOrderRequestDto);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/gift/controller/OptionController.java
+++ b/src/main/java/gift/controller/OptionController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/options")
 public class OptionController {
@@ -42,23 +44,23 @@ public class OptionController {
 
     /**
      * 옵션 생성
-     * @param name 옵션 이름
+     * @param body 옵션 이름
      * @return Option JSON
      */
     @PostMapping()
-    public ResponseEntity<Option> create(@RequestBody String name){
-        return new ResponseEntity<>(optionService.addOption(name), HttpStatus.CREATED);
+    public ResponseEntity<Option> create(@RequestBody Map<String, String> body){
+        return new ResponseEntity<>(optionService.addOption(body.get("name")), HttpStatus.CREATED);
     }
 
     /**
      * 옵션 이름 수정
      * @param id 옵션 아이디
-     * @param name 바꿀 이름
+     * @param body 바꿀 이름
      * @return Option JSON
      */
     @PatchMapping("/{id}")
-    public ResponseEntity<Option> update(@PathVariable Long id, @RequestBody String name){
-        return new ResponseEntity<>(optionService.updateOption(id, name), HttpStatus.OK);
+    public ResponseEntity<Option> update(@PathVariable Long id, @RequestBody Map<String, String> body){
+        return new ResponseEntity<>(optionService.updateOption(id, body.get("name")), HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/products")
 public class ProductController {
@@ -94,13 +96,12 @@ public class ProductController {
     /**
      * 제품 옵션 추가
      * @param id 제품 id
-     * @param name 옵션 이름
-     * @param value 옵션 값
+     * @param body 옵션 이름, 재고 수량
      * @return Void
      */
     @PostMapping("/{id}/option")
-    public ResponseEntity<Void> addProductOption(@PathVariable Long id, @RequestBody String name, @RequestBody Long value) {
-        productService.addProductOption(id, name, value);
+    public ResponseEntity<Void> addProductOption(@PathVariable Long id, @RequestBody Map<String, String> body) {
+        productService.addProductOption(id, body.get("name"), Long.parseLong(body.get("quantity")));
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 

--- a/src/main/java/gift/dto/KakaoFeedMessageDto.java
+++ b/src/main/java/gift/dto/KakaoFeedMessageDto.java
@@ -1,0 +1,58 @@
+package gift.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoFeedMessageDto {
+
+    private String objectType = "feed";
+    private Content content;
+    private ItemContent itemContent;
+
+    public KakaoFeedMessageDto(Content content, ItemContent itemContent) {
+        this.content = content;
+        this.itemContent = itemContent;
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Content {
+        private String title = "아래와 같은 메세지가 받는 분께 전송됩니다.";
+        private String description; // 선물 메세지
+
+        public Content(String description) {
+            this.description = description;
+        }
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class ItemContent {
+        private String profileText = "주문해주셔서 감사합니다.";
+        private String profileImageUrl;
+        private String titleImageUrl; // 제품 이미지 링크
+        private String titleImageText; // 제품 이름
+        private List<Item> items; // 선택한 제품 옵션
+        private String sum = "총합";
+        private String sumOp; // 가격 총합 넣기
+
+        public ItemContent(String titleImageUrl, String titleImageText, List<Item> items, String sumOp) {
+            this.titleImageUrl = titleImageUrl;
+            this.titleImageText = titleImageText;
+            this.items = items;
+            this.sumOp = sumOp;
+        }
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Item {
+        private String item; // 제품 옵션 이름
+        private String itemOp; // 제품 옵션 가격
+
+        public Item(String item, String itemOp) {
+            this.item = item;
+            this.itemOp = itemOp;
+        }
+    }
+}

--- a/src/main/java/gift/dto/KakaoFeedMessageDto.java
+++ b/src/main/java/gift/dto/KakaoFeedMessageDto.java
@@ -1,10 +1,13 @@
 package gift.dto;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.List;
+import java.util.Map;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoFeedMessageDto {
 
@@ -17,22 +20,26 @@ public class KakaoFeedMessageDto {
         this.itemContent = itemContent;
     }
 
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class Content {
         private String title = "아래와 같은 메세지가 받는 분께 전송됩니다.";
         private String description; // 선물 메세지
+        private String imageUrl = "https://mud-kage.kakao.com/dn/NTmhS/btqfEUdFAUf/FjKzkZsnoeE4o19klTOVI1/openlink_640x640s.jpg";
+        private Map<String, String> link = Map.of("web_url", "http://www.daum.net", "mobile_web_url", "http://m.daum.net");
 
         public Content(String description) {
             this.description = description;
         }
     }
 
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class ItemContent {
         private String profileText = "주문해주셔서 감사합니다.";
-        private String profileImageUrl;
         private String titleImageUrl; // 제품 이미지 링크
         private String titleImageText; // 제품 이름
+        private String titleImageCategory = "카테고리";
         private List<Item> items; // 선택한 제품 옵션
         private String sum = "총합";
         private String sumOp; // 가격 총합 넣기
@@ -45,6 +52,7 @@ public class KakaoFeedMessageDto {
         }
     }
 
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class Item {
         private String item; // 제품 옵션 이름

--- a/src/main/java/gift/dto/KakaoOrderRequestDto.java
+++ b/src/main/java/gift/dto/KakaoOrderRequestDto.java
@@ -1,0 +1,5 @@
+package gift.dto;
+
+public record KakaoOrderRequestDto(Long optionId,
+                                   Long quantity,
+                                   String message) { }

--- a/src/main/java/gift/dto/WishRequestDto.java
+++ b/src/main/java/gift/dto/WishRequestDto.java
@@ -1,7 +1,7 @@
 package gift.dto;
 
-public record WishRequestDto(Long id, Long productId, Long quantity) {
-    public WishRequestDto(Long productId, Long quantity) {
-        this(null, productId, quantity);
+public record WishRequestDto(Long id, Long productOptionId, Long quantity) {
+    public WishRequestDto(Long productOptionId, Long quantity) {
+        this(null, productOptionId, quantity);
     }
 }

--- a/src/main/java/gift/dto/WishResponseDto.java
+++ b/src/main/java/gift/dto/WishResponseDto.java
@@ -2,8 +2,8 @@ package gift.dto;
 
 import gift.entity.Wish;
 
-public record WishResponseDto(Long id, Long productId, Long quantity) {
+public record WishResponseDto(Long id, Long productOptionId, Long quantity) {
     public WishResponseDto(Wish wish) {
-        this(wish.getId(), wish.getProductId(), wish.getQuantity());
+        this(wish.getId(), wish.getProductOption().getId(), wish.getQuantity());
     }
 }

--- a/src/main/java/gift/entity/KakaoToken.java
+++ b/src/main/java/gift/entity/KakaoToken.java
@@ -1,0 +1,52 @@
+package gift.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "kakao_token")
+public class KakaoToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String tokenType;
+    private String accessToken;
+    private String idToken;
+
+    private LocalDateTime expiresDate; // 서비스 레이어에서 계산 필요
+
+    private String refreshToken;
+    private LocalDateTime refreshTokenExpiresDate; // 서비스 레이어에서 계산 필요
+    private String scope;
+
+    protected KakaoToken() {}
+
+    public KakaoToken(String tokenType, String accessToken, String idToken, LocalDateTime expiresDate, String refreshToken, LocalDateTime refreshTokenExpiresDate, String scope) {
+        this.tokenType = tokenType;
+        this.accessToken = accessToken;
+        this.idToken = idToken;
+        this.expiresDate = expiresDate;
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpiresDate = refreshTokenExpiresDate;
+        this.scope = scope;
+    }
+
+    public void updateAccessToken(String accessToken, LocalDateTime expiresDate){
+        this.accessToken = accessToken;
+        this.expiresDate = expiresDate;
+    }
+
+    public void updateRefreshToken(String refreshToken, LocalDateTime refreshTokenExpiresDate){
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpiresDate = refreshTokenExpiresDate;
+    }
+
+    public Long getId() {return id;}
+    public String getTokenType() {return tokenType;}
+    public String getAccessToken() {return accessToken;}
+    public String getIdToken() {return idToken;}
+    public LocalDateTime getExpiresDate() {return expiresDate;}
+    public String getRefreshToken() {return refreshToken;}
+    public LocalDateTime getRefreshTokenExpiresDate() {return refreshTokenExpiresDate;}
+    public String getScope() {return scope;}
+}

--- a/src/main/java/gift/entity/ProductOption.java
+++ b/src/main/java/gift/entity/ProductOption.java
@@ -14,30 +14,30 @@ public class ProductOption {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.REMOVE)
     @JoinColumn(name = "product_id")
     private Product product;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.REMOVE)
     @JoinColumn(name = "option_id")
     private Option option;
 
-    private Long value;
+    private Long stock;
 
     protected ProductOption() {}
 
-    public ProductOption(Product product, Option option, Long value) {
+    public ProductOption(Product product, Option option, Long stock) {
         this.product = product;
         this.option = option;
-        this.value = value;
+        this.stock = stock;
     }
 
-    public void subtract(Long value){
-        this.value -= value;
+    public void subtract(Long stock){
+        this.stock -= stock;
     }
 
     public Long getId() { return id; }
     public Product getProduct() { return product; }
     public Option getOption() { return option; }
-    public Long getValue() { return value; }
+    public Long getStock() { return stock; }
 }

--- a/src/main/java/gift/entity/ProductOption.java
+++ b/src/main/java/gift/entity/ProductOption.java
@@ -32,8 +32,12 @@ public class ProductOption {
         this.stock = stock;
     }
 
-    public void subtract(Long stock){
+    public void subtract(Long stock) {
         this.stock -= stock;
+        if (this.stock < 0) {
+            this.stock += stock;
+            throw new RuntimeException("재고가 없습니다.");
+        }
     }
 
     public Long getId() { return id; }

--- a/src/main/java/gift/entity/User.java
+++ b/src/main/java/gift/entity/User.java
@@ -38,6 +38,10 @@ public class User {
         this.password = password;
     }
 
+    public void updateKakaoToken(KakaoToken kakaoToken){
+        this.kakaoToken = kakaoToken;
+    }
+
     public Long getId() {return id;}
     public String getEmail() {return email;}
     public String getPassword() {return password;}

--- a/src/main/java/gift/entity/User.java
+++ b/src/main/java/gift/entity/User.java
@@ -23,6 +23,9 @@ public class User {
 
     private String role;
 
+    @OneToOne
+    private KakaoToken kakaoToken;
+
     protected User() {}
 
     public User(String email, String password) {

--- a/src/main/java/gift/entity/User.java
+++ b/src/main/java/gift/entity/User.java
@@ -47,4 +47,5 @@ public class User {
     public String getPassword() {return password;}
     public LocalDateTime getCreatedDate() {return createdDate;}
     public String getRole() {return role;}
+    public KakaoToken getKakaoToken() {return kakaoToken;}
 }

--- a/src/main/java/gift/entity/User.java
+++ b/src/main/java/gift/entity/User.java
@@ -5,6 +5,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name= "user")
@@ -25,6 +27,9 @@ public class User {
 
     @OneToOne
     private KakaoToken kakaoToken;
+
+    @OneToMany(mappedBy = "user")
+    private List<Wish> wishList = new ArrayList<>();
 
     protected User() {}
 
@@ -48,4 +53,5 @@ public class User {
     public LocalDateTime getCreatedDate() {return createdDate;}
     public String getRole() {return role;}
     public KakaoToken getKakaoToken() {return kakaoToken;}
+    public List<Wish> getWishList() {return wishList;}
 }

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -1,6 +1,5 @@
 package gift.entity;
 
-import gift.dto.WishRequestDto;
 import jakarta.persistence.*;
 
 @Entity
@@ -11,22 +10,22 @@ public class Wish {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long userId;
-    private Long productId;
+    @ManyToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "product_id")
+    private ProductOption productOption;
+
     private Long quantity;
 
     protected Wish() {}
 
-    public Wish(Long userId, Long productId, Long quantity) {
-        this.userId = userId;
-        this.productId = productId;
+    public Wish(User user, ProductOption productOption, Long quantity) {
+        this.user = user;
+        this.productOption = productOption;
         this.quantity = quantity;
-    }
-
-    public Wish(WishRequestDto wishRequestDto) {
-        id = wishRequestDto.id();
-        productId = wishRequestDto.productId();
-        quantity = wishRequestDto.quantity();
     }
 
     public void update(Long quantity) {
@@ -34,7 +33,7 @@ public class Wish {
     }
 
     public Long getId() {return id;}
-    public Long getUserId() {return userId;}
-    public Long getProductId() {return productId;}
+    public User getUser() {return user;}
+    public ProductOption getProductOption() {return productOption;}
     public Long getQuantity() {return quantity;}
 }

--- a/src/main/java/gift/infrastructure/KakaoAuthClient.java
+++ b/src/main/java/gift/infrastructure/KakaoAuthClient.java
@@ -3,52 +3,55 @@ package gift.infrastructure;
 import gift.dto.KakaoTokenDto;
 import gift.dto.KakaoUserInfoDto;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.RestTemplate;
-
-import java.net.URI;
 
 @Service
 public class KakaoAuthClient {
     private final String kakaoRestApiKey;
     private final String redirectUri;
+    private final String clientSecret;
     private final RestTemplate restTemplate;
 
     public KakaoAuthClient(@Value("${kakao_rest_api_key}") String kakaoRestApiKey,
                             @Value("${redirect_uri}") String redirectUri,
+                            @Value("${client_secret}") String clientSecret,
                             RestTemplate kakaoAuthRestTemplate) {
         this.kakaoRestApiKey = kakaoRestApiKey;
         this.redirectUri = redirectUri;
+        this.clientSecret = clientSecret;
         this.restTemplate = kakaoAuthRestTemplate;
     }
 
     public KakaoTokenDto getKakaoToken(String code) {
-        final String url = "/token";
+        final String url = "https://kauth.kakao.com/oauth/token";
+
+        var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         var body = new LinkedMultiValueMap<String, String>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", kakaoRestApiKey);
         body.add("redirect_uri", redirectUri);
         body.add("code", code);
+        body.add("client_secret", clientSecret);
 
-        var request = new RequestEntity<>(body, HttpMethod.POST, URI.create(url));
-        ResponseEntity<KakaoTokenDto> response = restTemplate.exchange(request, KakaoTokenDto.class);
+        var httpentity = new HttpEntity<>(body, headers);
 
+        ResponseEntity<KakaoTokenDto> response = restTemplate.exchange(url, HttpMethod.POST, httpentity, KakaoTokenDto.class);
         return response.getBody();
     }
 
     public KakaoUserInfoDto getKakaoUserInfo(KakaoTokenDto token) {
-        final String url = "/userinfo";
+        final String url = "https://kapi.kakao.com/v1/oidc/userinfo";
         var headers = new HttpHeaders();
         headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken());
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        var request = new RequestEntity<>(headers, HttpMethod.GET, URI.create(url));
-        ResponseEntity<KakaoUserInfoDto> response = restTemplate.exchange(request, KakaoUserInfoDto.class);
+        var httpentity = new HttpEntity<>(headers);
+        ResponseEntity<KakaoUserInfoDto> response = restTemplate.exchange(url, HttpMethod.GET, httpentity, KakaoUserInfoDto.class);
         return response.getBody();
     }
 }

--- a/src/main/java/gift/infrastructure/KakaoAuthClient.java
+++ b/src/main/java/gift/infrastructure/KakaoAuthClient.java
@@ -14,20 +14,23 @@ public class KakaoAuthClient {
     private final String kakaoRestApiKey;
     private final String redirectUri;
     private final String clientSecret;
-    private final RestTemplate restTemplate;
+    private final RestTemplate kakaoAuthRestTemplate;
+    private final RestTemplate kakaoKapiRestTemplate;
 
     public KakaoAuthClient(@Value("${kakao_rest_api_key}") String kakaoRestApiKey,
-                            @Value("${redirect_uri}") String redirectUri,
-                            @Value("${client_secret}") String clientSecret,
-                            RestTemplate kakaoAuthRestTemplate) {
+                           @Value("${redirect_uri}") String redirectUri,
+                           @Value("${client_secret}") String clientSecret,
+                           RestTemplate kakaoAuthRestTemplate,
+                           RestTemplate kakaoKapiRestTemplate) {
         this.kakaoRestApiKey = kakaoRestApiKey;
         this.redirectUri = redirectUri;
         this.clientSecret = clientSecret;
-        this.restTemplate = kakaoAuthRestTemplate;
+        this.kakaoAuthRestTemplate = kakaoAuthRestTemplate;
+        this.kakaoKapiRestTemplate = kakaoKapiRestTemplate;
     }
 
     public KakaoTokenDto getKakaoToken(String code) {
-        final String url = "https://kauth.kakao.com/oauth/token";
+        final String url = "/oauth/token";
 
         var headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -41,18 +44,18 @@ public class KakaoAuthClient {
 
         var httpentity = new HttpEntity<>(body, headers);
 
-        ResponseEntity<KakaoTokenDto> response = restTemplate.exchange(url, HttpMethod.POST, httpentity, KakaoTokenDto.class);
+        ResponseEntity<KakaoTokenDto> response = kakaoAuthRestTemplate.exchange(url, HttpMethod.POST, httpentity, KakaoTokenDto.class);
         return response.getBody();
     }
 
     public KakaoUserInfoDto getKakaoUserInfo(KakaoToken token) {
-        final String url = "https://kapi.kakao.com/v1/oidc/userinfo";
+        final String url = "/v1/oidc/userinfo";
         var headers = new HttpHeaders();
         headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token.getAccessToken());
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         var httpentity = new HttpEntity<>(headers);
-        ResponseEntity<KakaoUserInfoDto> response = restTemplate.exchange(url, HttpMethod.GET, httpentity, KakaoUserInfoDto.class);
+        ResponseEntity<KakaoUserInfoDto> response = kakaoKapiRestTemplate.exchange(url, HttpMethod.GET, httpentity, KakaoUserInfoDto.class);
         return response.getBody();
     }
 }

--- a/src/main/java/gift/infrastructure/KakaoAuthClient.java
+++ b/src/main/java/gift/infrastructure/KakaoAuthClient.java
@@ -2,6 +2,7 @@ package gift.infrastructure;
 
 import gift.dto.KakaoTokenDto;
 import gift.dto.KakaoUserInfoDto;
+import gift.entity.KakaoToken;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -44,10 +45,10 @@ public class KakaoAuthClient {
         return response.getBody();
     }
 
-    public KakaoUserInfoDto getKakaoUserInfo(KakaoTokenDto token) {
+    public KakaoUserInfoDto getKakaoUserInfo(KakaoToken token) {
         final String url = "https://kapi.kakao.com/v1/oidc/userinfo";
         var headers = new HttpHeaders();
-        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken());
+        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token.getAccessToken());
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         var httpentity = new HttpEntity<>(headers);

--- a/src/main/java/gift/infrastructure/KakaoServiceClient.java
+++ b/src/main/java/gift/infrastructure/KakaoServiceClient.java
@@ -33,7 +33,6 @@ public class KakaoServiceClient {
             json = objectMapper
                     .writerWithDefaultPrettyPrinter()      // 보기 좋게 포맷팅
                     .writeValueAsString(feedMessageDto);
-            System.out.println("▶ feedMessageDto JSON =\n" + json); // 디버그용
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -44,8 +43,5 @@ public class KakaoServiceClient {
         var httpentity = new HttpEntity<>(body, headers);
 
         var response = kakaoKapiRestTemplate.exchange(url, HttpMethod.POST, httpentity, String.class);
-
-        System.out.println(response.getBody()); // 디버그용
-        System.out.println(response.getStatusCode()); // 디버그용
     }
 }

--- a/src/main/java/gift/infrastructure/KakaoServiceClient.java
+++ b/src/main/java/gift/infrastructure/KakaoServiceClient.java
@@ -1,7 +1,10 @@
 package gift.infrastructure;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gift.dto.KakaoFeedMessageDto;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -9,28 +12,40 @@ import org.springframework.web.client.RestTemplate;
 
 @Service
 public class KakaoServiceClient {
+    private final ObjectMapper objectMapper;
+
     private final RestTemplate kakaoKapiRestTemplate;
 
-    public KakaoServiceClient(RestTemplate kakaoKapiRestTemplate) {
+    public KakaoServiceClient(RestTemplate kakaoKapiRestTemplate, ObjectMapper objectMapper) {
         this.kakaoKapiRestTemplate = kakaoKapiRestTemplate;
+        this.objectMapper = objectMapper;
     }
 
     public void sendFeedMessageToMe (String accessToken, KakaoFeedMessageDto feedMessageDto) {
         final String url = "/v2/api/talk/memo/default/send";
+        String json;
 
         var headers = new HttpHeaders();
         headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        var body = new LinkedMultiValueMap<String, KakaoFeedMessageDto>();
-        body.add("template_object", feedMessageDto);
+        try {
+            json = objectMapper
+                    .writerWithDefaultPrettyPrinter()      // 보기 좋게 포맷팅
+                    .writeValueAsString(feedMessageDto);
+            System.out.println("▶ feedMessageDto JSON =\n" + json); // 디버그용
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
-        var response = kakaoKapiRestTemplate.postForEntity(url, body, Integer.class, headers);
+        var body = new LinkedMultiValueMap<String, String>();
+        body.add("template_object", json);
+
+        var httpentity = new HttpEntity<>(body, headers);
+
+        var response = kakaoKapiRestTemplate.exchange(url, HttpMethod.POST, httpentity, String.class);
 
         System.out.println(response.getBody()); // 디버그용
         System.out.println(response.getStatusCode()); // 디버그용
-
-        if (response.getBody() != 0)
-            throw new RuntimeException("메세지가 전송되지 않았습니다.");
     }
 }

--- a/src/main/java/gift/infrastructure/KakaoServiceClient.java
+++ b/src/main/java/gift/infrastructure/KakaoServiceClient.java
@@ -1,0 +1,36 @@
+package gift.infrastructure;
+
+import gift.dto.KakaoFeedMessageDto;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class KakaoServiceClient {
+    private final RestTemplate kakaoKapiRestTemplate;
+
+    public KakaoServiceClient(RestTemplate kakaoKapiRestTemplate) {
+        this.kakaoKapiRestTemplate = kakaoKapiRestTemplate;
+    }
+
+    public void sendFeedMessageToMe (String accessToken, KakaoFeedMessageDto feedMessageDto) {
+        final String url = "/v2/api/talk/memo/default/send";
+
+        var headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        var body = new LinkedMultiValueMap<String, KakaoFeedMessageDto>();
+        body.add("template_object", feedMessageDto);
+
+        var response = kakaoKapiRestTemplate.postForEntity(url, body, Integer.class, headers);
+
+        System.out.println(response.getBody()); // 디버그용
+        System.out.println(response.getStatusCode()); // 디버그용
+
+        if (response.getBody() != 0)
+            throw new RuntimeException("메세지가 전송되지 않았습니다.");
+    }
+}

--- a/src/main/java/gift/repository/KakaoTokenRepository.java
+++ b/src/main/java/gift/repository/KakaoTokenRepository.java
@@ -1,0 +1,7 @@
+package gift.repository;
+
+import gift.entity.KakaoToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KakaoTokenRepository extends JpaRepository<KakaoToken, Long> {
+}

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface WishRepository extends JpaRepository<Wish, Long> {
     Page<Wish> findByUserId(Long userId, Pageable pageable);
-    boolean existsByProductId(Long productId);
+    boolean existsByProductOptionId(Long productOptionId);
 }

--- a/src/main/java/gift/service/KakaoAuthService.java
+++ b/src/main/java/gift/service/KakaoAuthService.java
@@ -2,19 +2,50 @@ package gift.service;
 
 import gift.dto.KakaoTokenDto;
 import gift.dto.KakaoUserInfoDto;
+import gift.dto.UserInfoDto;
+import gift.entity.KakaoToken;
+import gift.entity.User;
+import gift.exception.NotFoundException;
 import gift.infrastructure.KakaoAuthClient;
+import gift.repository.KakaoTokenRepository;
+import gift.repository.UserRepository;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 public class KakaoAuthService {
     private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoTokenRepository kakaoTokenRepository;
+    private final UserRepository userRepository;
 
-    public KakaoAuthService(KakaoAuthClient kakaoAuthClient) {
+    public KakaoAuthService(KakaoAuthClient kakaoAuthClient,
+                            KakaoTokenRepository kakaoTokenRepository,
+                            UserRepository userRepository) {
         this.kakaoAuthClient = kakaoAuthClient;
+        this.kakaoTokenRepository = kakaoTokenRepository;
+        this.userRepository = userRepository;
     }
 
-    public KakaoTokenDto getKakaoToken(String code) {
-        return kakaoAuthClient.getKakaoToken(code);
+    public KakaoTokenDto accessKakaoToken(UserInfoDto userInfoDto, String code) {
+        KakaoTokenDto kakaoTokenDto = kakaoAuthClient.getKakaoToken(code);
+        LocalDateTime expiresDate = LocalDateTime.now().plusSeconds(kakaoTokenDto.expiresIn());
+        LocalDateTime refreshTokenExpiresDate = LocalDateTime.now().plusSeconds(kakaoTokenDto.refreshTokenExpiresIn());
+
+        KakaoToken kakaoToken = new KakaoToken(kakaoTokenDto.tokenType(),
+                kakaoTokenDto.accessToken(),
+                kakaoTokenDto.idToken(),
+                expiresDate,
+                kakaoTokenDto.refreshToken(),
+                refreshTokenExpiresDate,
+                kakaoTokenDto.scope());
+
+        kakaoToken = kakaoTokenRepository.save(kakaoToken);
+
+        User user = userRepository.findById(userInfoDto.id()).orElseThrow(() -> new NotFoundException("User", userInfoDto.id()));
+        user.updateKakaoToken(kakaoToken);
+
+        return kakaoTokenDto;
     }
 
     public KakaoUserInfoDto getKakaoUserInfo(KakaoTokenDto token) {

--- a/src/main/java/gift/service/KakaoAuthService.java
+++ b/src/main/java/gift/service/KakaoAuthService.java
@@ -9,6 +9,7 @@ import gift.exception.NotFoundException;
 import gift.infrastructure.KakaoAuthClient;
 import gift.repository.KakaoTokenRepository;
 import gift.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -27,6 +28,7 @@ public class KakaoAuthService {
         this.userRepository = userRepository;
     }
 
+    @Transactional
     public KakaoTokenDto accessKakaoToken(UserInfoDto userInfoDto, String code) {
         KakaoTokenDto kakaoTokenDto = kakaoAuthClient.getKakaoToken(code);
         LocalDateTime expiresDate = LocalDateTime.now().plusSeconds(kakaoTokenDto.expiresIn());
@@ -48,6 +50,7 @@ public class KakaoAuthService {
         return kakaoTokenDto;
     }
 
+    @Transactional
     public KakaoUserInfoDto getKakaoUserInfo(UserInfoDto userInfoDto) {
         User user = userRepository.findById(userInfoDto.id()).orElseThrow(() -> new NotFoundException("User", userInfoDto.id()));
         return kakaoAuthClient.getKakaoUserInfo(user.getKakaoToken());

--- a/src/main/java/gift/service/KakaoAuthService.java
+++ b/src/main/java/gift/service/KakaoAuthService.java
@@ -48,7 +48,8 @@ public class KakaoAuthService {
         return kakaoTokenDto;
     }
 
-    public KakaoUserInfoDto getKakaoUserInfo(KakaoTokenDto token) {
-        return kakaoAuthClient.getKakaoUserInfo(token);
+    public KakaoUserInfoDto getKakaoUserInfo(UserInfoDto userInfoDto) {
+        User user = userRepository.findById(userInfoDto.id()).orElseThrow(() -> new NotFoundException("User", userInfoDto.id()));
+        return kakaoAuthClient.getKakaoUserInfo(user.getKakaoToken());
     }
 }

--- a/src/main/java/gift/service/KakaoOrderService.java
+++ b/src/main/java/gift/service/KakaoOrderService.java
@@ -1,0 +1,60 @@
+package gift.service;
+
+import gift.dto.KakaoFeedMessageDto;
+import gift.dto.KakaoOrderRequestDto;
+import gift.dto.UserInfoDto;
+import gift.entity.ProductOption;
+import gift.entity.User;
+import gift.exception.NotFoundException;
+import gift.infrastructure.KakaoServiceClient;
+import gift.repository.ProductOptionRepository;
+import gift.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class KakaoOrderService {
+    private final UserRepository userRepository;
+    private final ProductOptionRepository productOptionRepository;
+    private final KakaoServiceClient kakaoServiceClient;
+
+    public KakaoOrderService(UserRepository userRepository,
+                             ProductOptionRepository productOptionRepository,
+                             KakaoServiceClient kakaoServiceClient) {
+        this.userRepository = userRepository;
+        this.productOptionRepository = productOptionRepository;
+        this.kakaoServiceClient = kakaoServiceClient;
+    }
+
+    @Transactional
+    public void orderProduct(UserInfoDto userInfoDto, KakaoOrderRequestDto kakaoOrderRequestDto) {
+        User user = userRepository.findById(userInfoDto.id()).orElseThrow(() -> new NotFoundException("User", userInfoDto.id()));
+        String accessToken = user.getKakaoToken().getAccessToken();
+
+        // 제품 옵션 재고 차감 및 확인
+        ProductOption productOption = productOptionRepository.findById(kakaoOrderRequestDto.optionId()).orElseThrow(() -> new NotFoundException("ProductOption", kakaoOrderRequestDto.optionId()));
+        try {
+            productOption.subtract(kakaoOrderRequestDto.quantity());
+        } catch(Exception e) {
+            throw new IllegalArgumentException("재고가 없습니다.");
+        }
+
+        // 주문자 피드 메세지 생성
+        List<KakaoFeedMessageDto.Item> items = List.of(new KakaoFeedMessageDto.Item(
+                productOption.getOption().getName(),
+                productOption.getProduct().getPrice().toString()));
+
+        KakaoFeedMessageDto kakaoFeedMessageDto = new KakaoFeedMessageDto(
+                new KakaoFeedMessageDto.Content(kakaoOrderRequestDto.message()),
+                new KakaoFeedMessageDto.ItemContent(
+                        productOption.getProduct().getImageUrl(),
+                        productOption.getProduct().getName(),
+                        items,
+                        productOption.getProduct().getPrice().toString())
+        );
+
+        kakaoServiceClient.sendFeedMessageToMe(accessToken, kakaoFeedMessageDto);
+    }
+}

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -6,6 +6,8 @@ import gift.dto.WishResponseDto;
 import gift.entity.Wish;
 import gift.exception.DuplicateException;
 import gift.exception.NotFoundException;
+import gift.repository.ProductOptionRepository;
+import gift.repository.UserRepository;
 import gift.repository.WishRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,9 +17,15 @@ import org.springframework.stereotype.Service;
 public class WishService {
 
     private final WishRepository wishRepository;
+    private final ProductOptionRepository productOptionRepository;
+    private final UserRepository userRepository;
 
-    public WishService(WishRepository wishRepository) {
+    public WishService(WishRepository wishRepository,
+                       ProductOptionRepository productOptionRepository,
+                       UserRepository userRepository) {
         this.wishRepository = wishRepository;
+        this.productOptionRepository = productOptionRepository;
+        this.userRepository = userRepository;
     }
 
     public Page<WishResponseDto> findUserWishes(UserInfoDto userInfoDto, Pageable pageable) {
@@ -25,11 +33,13 @@ public class WishService {
     }
 
     public WishResponseDto addWish(UserInfoDto userInfoDto, WishRequestDto wishRequestDto) {
-        if (wishRepository.existsByProductId(wishRequestDto.productId())) {  // 제품 중복 검사
+        if (wishRepository.existsByProductOptionId(wishRequestDto.productOptionId())) {  // 제품 중복 검사
             throw new DuplicateException("이미 리스트에 존재하는 제품입니다.");
         }
 
-        Wish wish = new Wish(userInfoDto.id(), wishRequestDto.productId(), wishRequestDto.quantity());
+        Wish wish = new Wish(userRepository.findById(userInfoDto.id()).orElseThrow(() -> new NotFoundException("User", userInfoDto.id())),
+                productOptionRepository.findById(wishRequestDto.productOptionId()).orElseThrow(() -> new NotFoundException("Product", wishRequestDto.productOptionId())),
+                wishRequestDto.quantity());
         return new WishResponseDto(wishRepository.save(wish));
     }
 

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -9,6 +9,7 @@ import gift.exception.NotFoundException;
 import gift.repository.ProductOptionRepository;
 import gift.repository.UserRepository;
 import gift.repository.WishRepository;
+import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,10 +29,12 @@ public class WishService {
         this.userRepository = userRepository;
     }
 
+    @Transactional
     public Page<WishResponseDto> findUserWishes(UserInfoDto userInfoDto, Pageable pageable) {
         return wishRepository.findByUserId(userInfoDto.id(), pageable).map(WishResponseDto::new);
     }
 
+    @Transactional
     public WishResponseDto addWish(UserInfoDto userInfoDto, WishRequestDto wishRequestDto) {
         if (wishRepository.existsByProductOptionId(wishRequestDto.productOptionId())) {  // 제품 중복 검사
             throw new DuplicateException("이미 리스트에 존재하는 제품입니다.");
@@ -43,11 +46,13 @@ public class WishService {
         return new WishResponseDto(wishRepository.save(wish));
     }
 
+    @Transactional
     public void updateWish(WishRequestDto wishRequestDto) {
         Wish wish = wishRepository.findById(wishRequestDto.id()).orElseThrow(() -> new NotFoundException("wish", wishRequestDto.id()));
         wish.update(wishRequestDto.quantity());
     }
 
+    @Transactional
     public void deleteWish(WishRequestDto wishRequestDto) {
         wishRepository.deleteById(wishRequestDto.id());
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,9 @@ spring.jpa.properties.hibernate.auto_quote_keyword=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
 
+logging.level.org.springframework.web.client.RestTemplate=DEBUG
+logging.level.org.apache.http.wire=DEBUG
+
 # MD\uC640 \uD611\uC758\uD574\uC11C \uC0AC\uC6A9\uD574\uC57C \uD558\uB294 \uB2E8\uC5B4
 forbidden_words=\uCE74\uCE74\uC624
 

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -1,7 +1,6 @@
 package gift.repository;
 
-import gift.dto.WishRequestDto;
-import gift.entity.Wish;
+import gift.entity.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -13,70 +12,83 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.assertj.core.api.Assertions.tuple;
 
 @DataJpaTest
 public class WishRepositoryTest {
     @Autowired
+    private UserRepository userRepository;
+    @Autowired
     private WishRepository wishRepository;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private OptionRepository optionRepository;
+    @Autowired
+    private ProductOptionRepository productOptionRepository;
 
     @Test
     void save() {
-        WishRequestDto wishRequestDto = new WishRequestDto(1L, 3L);
-        Wish expected = new Wish(wishRequestDto);
+        User expectUser = new User("kakao@kakao.com", "1234");
+        Product expectProduct = productRepository.save(new Product("과자", 1000L, "http://snack"));
+        Option expectOption = optionRepository.save(new Option("할인율"));
+        ProductOption expectProductOption = productOptionRepository.save(new ProductOption(expectProduct, expectOption, 30L));
+        Wish expected = new Wish(expectUser, expectProductOption, 30L);
+
         Wish actual = wishRepository.save(expected);
         assertAll(
                 () -> assertThat(actual.getId()).isNotNull(),
-                () -> assertThat(actual.getProductId()).isEqualTo(expected.getProductId()),
+                () -> assertThat(actual.getUser()).isEqualTo(expected.getUser()),
+                () -> assertThat(actual.getProductOption()).isEqualTo(expected.getProductOption()),
                 () -> assertThat(actual.getQuantity()).isEqualTo(expected.getQuantity())
         );
     }
 
     @Test
     void findById() {
-        Wish wish1 = wishRepository.save(new Wish(new WishRequestDto(1L, 3L)));
-        Wish wish2 = wishRepository.findById(wish1.getId()).orElse(null);
-        assertThat(wish1).isEqualTo(wish2);
+        User expectUser = new User("kakao@kakao.com", "1234");
+        Product expectProduct = productRepository.save(new Product("과자", 1000L, "http://snack"));
+        Option expectOption = optionRepository.save(new Option("할인율"));
+        ProductOption expectProductOption = productOptionRepository.save(new ProductOption(expectProduct, expectOption, 30L));
+        Wish expected = wishRepository.save(new Wish(expectUser, expectProductOption, 30L));
+        
+        Wish actual = wishRepository.findById(expected.getId()).orElse(null);
+        assertThat(expected).isEqualTo(actual);
     }
 
     @Test
-    void existsByProductId() {
-        Wish wish1 = wishRepository.save(new Wish(new WishRequestDto(1L, 3L)));
-        boolean flag = wishRepository.existsByProductId(wish1.getId());
-        assertThat(flag).isFalse();
+    void existsByProductOptionId() {
+        User expectUser = userRepository.save(new User("kakao@kakao.com", "1234"));
+        Product expectProduct = productRepository.save(new Product("과자", 1000L, "http://snack"));
+        Option expectOption = optionRepository.save(new Option("할인율"));
+        ProductOption expectProductOption = productOptionRepository.save(new ProductOption(expectProduct, expectOption, 30L));
+        Wish expected = wishRepository.save(new Wish(expectUser, expectProductOption, 30L));
+        
+        boolean flag = wishRepository.existsByProductOptionId(expected.getProductOption().getId());
+        assertThat(flag).isTrue();
     }
 
     @Test
     void sortByUserIdAsc() {
-        wishRepository.save(new Wish(2L, 3L, 3L));
-        wishRepository.save(new Wish(1L, 3L, 3L));
-        wishRepository.save(new Wish(3L, 3L, 3L));
+        User expectUser1 = userRepository.save(new User("kakao@kakao.com", "1234"));
+        User expectUser2 = userRepository.save(new User("kakao2@kakao.com", "1234"));
+        User expectUser3 = userRepository.save(new User("kakao3@kakao.com", "1234"));
+        Product expectProduct = productRepository.save(new Product("과자", 1000L, "http://snack"));
+        Option expectOption1 = optionRepository.save(new Option("할인율"));
+        Option expectOption2 = optionRepository.save(new Option("땅콩맛"));
+        Option expectOption3 = optionRepository.save(new Option("우유맛"));
+        ProductOption expectProductOption1 = productOptionRepository.save(new ProductOption(expectProduct, expectOption1, 30L));
+        ProductOption expectProductOption2 = productOptionRepository.save(new ProductOption(expectProduct, expectOption2, 30L));
+        ProductOption expectProductOption3 = productOptionRepository.save(new ProductOption(expectProduct, expectOption3, 30L));
+        
+        wishRepository.save(new Wish(expectUser3, expectProductOption1, 3L));
+        wishRepository.save(new Wish(expectUser1, expectProductOption2, 3L));
+        wishRepository.save(new Wish(expectUser2, expectProductOption3, 3L));
         Page<Wish> page = wishRepository.findAll(
                 PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "userId"))
         );
 
         List<Wish> wishes = page.getContent();
-        assertThat(wishes.stream().map(Wish::getUserId).toList())
-                .containsExactly(1L,2L,3L);
-    }
-
-    @Test
-    void sortByQuantityDescThenIdAsc() {
-        wishRepository.save(new Wish(3L, 3L, 2L));
-        wishRepository.save(new Wish(3L, 3L, 2L));
-        wishRepository.save(new Wish(3L, 3L, 3L));
-
-        Page<Wish> page = wishRepository.findAll(
-                PageRequest.of(0, 20,
-                        Sort.by(Sort.Order.desc("quantity"), Sort.Order.asc("id")))
-        );
-
-        assertThat(page.getContent())
-                .extracting(Wish::getQuantity, Wish::getId)
-                .containsExactly(
-                        tuple(3L, 5L),
-                        tuple(2L, 3L),
-                        tuple(2L, 4L)
-                );
+        assertThat(wishes.stream().map(Wish::getUser).toList())
+                .containsExactly(expectUser1, expectUser2 , expectUser3);
     }
 }

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -1,6 +1,7 @@
 package gift.repository;
 
 import gift.entity.*;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -25,6 +26,8 @@ public class WishRepositoryTest {
     private OptionRepository optionRepository;
     @Autowired
     private ProductOptionRepository productOptionRepository;
+    @Autowired
+    private EntityManager em;
 
     @Test
     void save() {
@@ -90,5 +93,26 @@ public class WishRepositoryTest {
         List<Wish> wishes = page.getContent();
         assertThat(wishes.stream().map(Wish::getUser).toList())
                 .containsExactly(expectUser1, expectUser2 , expectUser3);
+    }
+
+    @Test
+    void getWishListFromUser() {
+        User expectUser1 = userRepository.save(new User("kakao@kakao.com", "1234"));
+        Product expectProduct = productRepository.save(new Product("과자", 1000L, "http://snack"));
+        Option expectOption1 = optionRepository.save(new Option("땅콩맛"));
+        Option expectOption2 = optionRepository.save(new Option("우유맛"));
+        ProductOption expectProductOption1 = productOptionRepository.save(new ProductOption(expectProduct, expectOption1, 30L));
+        ProductOption expectProductOption2 = productOptionRepository.save(new ProductOption(expectProduct, expectOption2, 10L));
+        Wish expect1 = wishRepository.save(new Wish(expectUser1, expectProductOption1, 3L));
+        Wish expect2 = wishRepository.save(new Wish(expectUser1, expectProductOption2, 3L));
+
+        em.flush();
+        em.clear();
+
+        Wish actualWish1 = wishRepository.findById(expect1.getId()).orElse(null);
+        Wish actualWish2 = wishRepository.findById(expect2.getId()).orElse(null);
+        List<Wish> actual = userRepository.findById(expectUser1.getId()).get().getWishList();
+
+        assertThat(actual).containsExactly(actualWish1, actualWish2);
     }
 }


### PR DESCRIPTION
점점 제 애플리케이션이 복잡해지는 것이 느껴져 멘토님이 보기 쉽도록 최대한 자세히 적어보았습니다.

## 작업 사항

* [x] KakaoToken 테이블 생성 후 User와 1:1 참조하도록 추가
* [x] Wish, Product, Option, ProductOption 테이블 간의 연관관계 재정립
* [x] 주문하기 로직 및 카카오 메세지 전송 기능 구현
* [x] 테스트

## 상세 내용

### KakaoToken 테이블 생성 후 User와 1:1 참조하도록 추가
기존에 제 서비스에서 구현한 로그인, 회원가입 로직과 카카오 토큰을 어떻게 조합시킬지 고민이 많았습니다.
oAuth 2.0을 이용하여 카카오에게 인증을 맡길까 생각해보았지만 사업자 등록이 안돼있어 이메일, 전화번호 같은 공통 식별자는 받아오지 못하고 카카오 고유 회원번호만 조회할 수 있었기 때문에 기존 회원과 연동하지 못하는 문제가 있었습니다.

따라서 카카오 토큰을 로그인이 된 상태(자체 JWT 토큰을 받은 상태) 에서 발급받아 KakaoToken 엔티티로 저장하고 이를 User와 1:1 연동시켜 저장했습니다.

결론적으로 제 기존 회원관리 로직에 카카오토큰만 갖다 붙여 카카오톡 메세지 전송 권한을 얻는 느낌으로 구현했습니다.

### Wish, Product, Option, ProductOption 테이블 간의 연관관계 재정립
지금까지 데이터베이스를 따로따로 만들었던 탓인지 테이블 간 연관관계가 너무 많이 망가져있었습니다. 처음부터 기초를 다시 설계하여 테이블간 연관관계, CASCADE 설정 등을 추가하고 필드 수정도 했습니다.

<img width="968" height="758" alt="ER 다이어그램" src="https://github.com/user-attachments/assets/f3f1ea1b-55aa-4be7-bb62-060ac7f96bab" />

Product 와 Option의 N:N 관계 표현을 위하여 ProductOption 중간 테이블을 두되 ProductOption에 stock 필드를 추가하여 각 제품 옵션의 재고를 나타내도록 했습니다.
Wish는 ProductOption을 참조하고 quantity 필드를 두어 제품을 담은 수를 표현하도록 했습니다. quantity와 stock의 비교를 통해 재고가 남았는지 판별이 가능합니다.
User는 Wish와 1:N 관계를 이뤄 위시리스트를 얻을 수 있도록 설계했습니다.

### 주문하기 로직 및 카카오 메세지 전송 기능 구현
주문하기 로직을 구현하는 것에 있어 수많은 고려사항이 있겠지만(예 : 외부 API로부터 반환된 메시지에 따른 분기처리) 시간이 부족하여 일단 재고 체크만 구현했습니다....

입력 : productOption ID, 주문할 수량, 상대에게 보내는 메세지
productOption을 조회 후 주문할 수량이 재고보다 많은지 체크하고 재고가 없을 경우 예외를 반환합니다.
이후 카카오의 기본 메시지 템플릿(피드 B형)을 만들고 RestTemplate를 호출하여 카카오톡으로 메시지를 전송했습니다.

### 테스트

테스트코드를 작성해보려 헀으나 외부 API를 사용하려면 수많은 레이어와 상호작용해야 하는데 어떻게 코드를 작성해야할지 감이 안잡혀서 실패했습니다... 😢 어쩔 수 없이 Postman 프로그램을 통해 직접 컨트롤러를 호출하여 테스트했습니다.

1. 이메일과 비밀번호를 입력하여 회원가입
2. 이메일과 비밀번호를 입력하여 로그인 (JWT 발급)
3. 카카오 로그인을 하여 인가 코드를 받고 토큰 발급 후 내 계정과 연동
4. Option 생성 (신라면)
5. Product 생성 (과자)
6. ProductOption 생성 (신라면, 과자, 30개)
7. ProductOption ID, 주문 수량(3개), 보낼 메세지(생일 축하해~) 입력하여 카카오톡 메세지 전송

<img width="211" height="539" alt="image" src="https://github.com/user-attachments/assets/a3846482-9445-4816-8d79-04f047234703" />




### 질문
카카오톡 메시지 JSON 포맷팅을 위해 하나의 DTO에 여러개의 객체가 들어가도록 했습니다. 겨우 카카오톡 메시지 하나 보내는 것에 너무 긴 DTO와 코드가 발생하는 것 같은데 이렇게 JSON 메시지를 생성하는 것이 맞나요? 아니면 더 좋은 방법이 있을까요?

```
        // 주문자 피드 메세지 생성
        List<KakaoFeedMessageDto.Item> items = List.of(new KakaoFeedMessageDto.Item(
                productOption.getOption().getName(),
                productOption.getProduct().getPrice().toString()));

        KakaoFeedMessageDto kakaoFeedMessageDto = new KakaoFeedMessageDto(
                new KakaoFeedMessageDto.Content(kakaoOrderRequestDto.message()),
                new KakaoFeedMessageDto.ItemContent(
                        productOption.getProduct().getImageUrl(),
                        productOption.getProduct().getName(),
                        items,
                        productOption.getProduct().getPrice().toString())
        );
```